### PR TITLE
Avoid using Pkg internals with RegistryInstances

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,9 +8,11 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SPDX = "47358f48-d834-4249-91f5-f6185eb3d540"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+RegistryInstances = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
 
 [compat]
 SPDX = "0.3.1"
+RegistryInstances = "0.1.0"
 julia = "1.8"
 
 [extras]

--- a/src/PkgToSoftwareBOM.jl
+++ b/src/PkgToSoftwareBOM.jl
@@ -6,6 +6,7 @@ using Pkg
 using UUIDs
 using TOML
 using SPDX
+using RegistryInstances
 
 export spdxCreationData, spdxPackageInstructions
 

--- a/src/spdxBuild.jl
+++ b/src/spdxBuild.jl
@@ -22,7 +22,7 @@ function generateSPDX(docData::spdxCreationData= spdxCreationData(), sbomRegistr
 
     # Add description of the registries in use
     spdxDoc.DocumentComment= (ismissing(spdxDoc.DocumentComment) ? "" : "$(spdxDoc.DocumentComment)\n\n") * "Registries used for populating Package data:\n"
-    active_registries= Pkg.Registry.reachable_registries()
+    active_registries= reachable_registries()
     for reg in active_registries
         if reg.name in sbomRegistries
             spdxDoc.DocumentComment= spdxDoc.DocumentComment * 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,14 +18,13 @@ using UUIDs
     # Add Test Registry
     Pkg.Registry.add(RegistrySpec(url= "https://github.com/SamuraiAku/DummyRegistry.jl.git"))
 
-    testdir= mktempdir()
     @testset "README.md examples: Environment" begin
 
         ## Example #1
         sbom = generateSPDX()
         # The SBOM is too big and complex to check everything, but we can check some things
         root_relationships= filter(r -> r.RelationshipType=="DESCRIBES", sbom.Relationships)
-        @test issetequal(getproperty.(root_relationships, :RelatedSPDXID), ["SPDXRef-PkgToSoftwareBOM-6254a0f9-6143-4104-aa2e-fd339a2830a6", "SPDXRef-SPDX-47358f48-d834-4249-91f5-f6185eb3d540"])
+        @test issetequal(getproperty.(root_relationships, :RelatedSPDXID), ["SPDXRef-PkgToSoftwareBOM-6254a0f9-6143-4104-aa2e-fd339a2830a6", "SPDXRef-SPDX-47358f48-d834-4249-91f5-f6185eb3d540", "SPDXRef-RegistryInstances-2792f1a3-b283-48e8-9a74-f99dce5104f3"])
         @test !isempty(filter(p -> p.SPDXID == "SPDXRef-PkgToSoftwareBOM-6254a0f9-6143-4104-aa2e-fd339a2830a6", sbom.Packages))
         @test !isempty(filter(p -> p.SPDXID == "SPDXRef-SPDX-47358f48-d834-4249-91f5-f6185eb3d540", sbom.Packages))
         @test !isempty(filter(isequal(SpdxRelationshipV2("SPDXRef-SPDX-47358f48-d834-4249-91f5-f6185eb3d540 DEPENDENCY_OF SPDXRef-PkgToSoftwareBOM-6254a0f9-6143-4104-aa2e-fd339a2830a6")), sbom.Relationships))
@@ -88,8 +87,6 @@ using UUIDs
         @test SPDX_pkg.LicenseDeclared== myLicense
         @test SPDX_pkg.Copyright== myPackage_instr.copyright
         @test SPDX_pkg.Name== package_name
-
-
     end
 
     @testset "Repo Track + Dual registries" begin


### PR DESCRIPTION
Resolves #15.  Uses RegistryInstances to replace accessing Pkg internals to retrieve registry information