### PR TITLE
Add Artifacts to an SBOM

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,8 +6,8 @@ version = "0.1.7"
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SPDX = "47358f48-d834-4249-91f5-f6185eb3d540"
-TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 RegistryInstances = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,18 @@ This package produces a Software Bill of Materials (SBOM) describing your Julia 
 
 I created PkgToSoftwareBOM.jl to help the Julia ecosystem get prepared for the emerging future of software supply chain security. If we want to see Julia adoption to continue to grow, then we need to be able to easily create SBOMs to supply to the organizations using Julia packages.
 
-PkgToSoftwareBOM interfaces with the standard library Pkg to fill in the SBOM data fields. Information filled out today includes a complete dependency list, versions in use, where the package can be downloaded from, and a checksum. Future versions may be able to fill in additional fields including copyright text and software license.
+PkgToSoftwareBOM interfaces with the standard library Pkg to fill in the SBOM data fields. Information filled out today includes:
+- A complete package dependency list including
+    - versions in use
+    - where the package can be downloaded from
+    - SPDX verification code
+- A complete artifact list
+    - artifact version resolved to the target platform
+        - target platform may be changed by an advanced user
+    - where the artifact can be downloaded from
+    - download checksum
+
+Future versions may be able to fill in additional fields including copyright text and software license.
 
 PkgToSoftwareBOM defaults to using the General registry but can use other registries and even mutiple registries as the source(s) of package information.
 
@@ -177,4 +188,22 @@ For example to create a User Environment SBOM using the General registry and ano
 sbom= generateSPDX(spdxCreationData(), ["PrivateRegistry", "General"]);
 ```
 
-The second argument is a list of all the registries you would like to use. If you have a package that exists in both registries (for example, you've cloned the respository to your local network and you want to list that as the download location), PkgToSoftwareBOM will use the information from the first registry in the list that has valid information and ignore all subsequent registires
+The second argument is a list of all the registries you would like to use. If you have a package that exists in both registries (for example, you've cloned the respository to your local network and you want to list that as the download location), PkgToSoftwareBOM will use the information from the first registry in the list that has valid information and ignore all subsequent registries
+
+## How does PkgToSoftwareBOM target hardware platforms other than the one it is running on?
+
+Advanced users may wish to create an SBOM in which the artifacts are targeted to a different platform than the one that PkgToSoftwareBOM is running on.  For example, create an SBOM for an x86 linux installation from an M1 Macbook.
+
+To do this, the user must first create a platform object describing the target platform.  For example, to create a platform object for the hardware you are currently running on:
+```julia
+using Base.BinaryPlatforms
+myplatform= HostPlatform()
+```
+
+Creating a platform object for other hardware is left as an exercise for the advanced user.
+
+To pass the platform object to PkgToSoftwareBOM, use the keyword `TargetPlatform` when creating an `spdxCreationData` object
+
+```julia
+SPDX_docCreation= spdxCreationData(TargetPlatform= myplatform)
+```

--- a/examples/Environment_Example1.spdx.json
+++ b/examples/Environment_Example1.spdx.json
@@ -3,13 +3,13 @@
     "dataLicense": "CC0-1.0",
     "SPDXID": "SPDXRef-DOCUMENT",
     "name": "Julia Environment",
-    "documentNamespace": "https://spdx.org/spdxdocs/Julia_Environment-42764e97-0dda-412f-81ca-b8ffbd76c1fc",
+    "documentNamespace": "https://spdx.org/spdxdocs/Julia_Environment-852ce381-c662-45ae-be68-33a554d94feb",
     "creationInfo": {
         "creators": [
-            "Tool:  PkgToSBOM.jl  ()"
+            "Tool:  PkgToSoftwareBOM.jl"
         ],
-        "created": "2023-05-15T04:56:18Z",
-        "comment": "An example of a User Environment SBOM. Describes the dependencies for JSON.jl, CSV.jl, DataFrames.jl, and Plots.jl"
+        "created": "2023-12-31T06:59:42Z",
+        "comment": "Target Platform: macOS aarch64 {cxxstring_abi=cxx11, julia_version=1.9.2, libgfortran_version=5.0.0}"
     },
     "comment": "Registries used for populating Package data:\nGeneral registry: https://github.com/JuliaRegistries/General.git\nOfficial general Julia package registry where people can\nregister any package they want without too much debate about\nnaming and without enforced standards on documentation or\ntesting. We nevertheless encourage documentation, testing and\nsome amount of consideration when choosing package names.\n\n\n",
     "packages": [
@@ -32,18 +32,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "Preferences",
             "SPDXID": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
-            "versionInfo": "1.4.0",
+            "versionInfo": "1.4.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaPackaging/Preferences.jl.git@v1.4.0",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Preferences.jl.git@v1.4.1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "d560e285ded90e89d90ed6730f3bb814c01065bf"
+                "packageVerificationCodeValue": "7d309b5c11bb9302e95e1db94b3934c08436ed24"
             },
             "homepage": "https://github.com/JuliaPackaging/Preferences.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -53,18 +54,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "PrecompileTools",
             "SPDXID": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
-            "versionInfo": "1.1.1",
+            "versionInfo": "1.2.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaLang/PrecompileTools.jl.git@v1.1.1",
+            "downloadLocation": "git+https://github.com/JuliaLang/PrecompileTools.jl.git@v1.2.0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "8c8074a6b3f5098eaf72103aa81d5fd047d2f8de"
+                "packageVerificationCodeValue": "243d9436f32d0aeb8ddd8ee0bcfc2f44f5133ac7"
             },
             "homepage": "https://github.com/JuliaLang/PrecompileTools.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -74,18 +76,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "Parsers",
             "SPDXID": "SPDXRef-Parsers-69de0a69-1ddd-5017-9359-2bf0b02dc9f0",
-            "versionInfo": "2.5.9",
+            "versionInfo": "2.8.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaData/Parsers.jl.git@v2.5.9",
+            "downloadLocation": "git+https://github.com/JuliaData/Parsers.jl.git@v2.8.1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "a9eed41577a355326b78d24bfcdb0869a7657398"
+                "packageVerificationCodeValue": "90fde61e3f0b7f7d43bcf31ad37681d12a04480a"
             },
             "homepage": "https://github.com/JuliaData/Parsers.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -95,6 +98,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -116,6 +120,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -137,18 +142,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "PooledArrays",
             "SPDXID": "SPDXRef-PooledArrays-2dfb63ee-cc39-5dd5-95bd-886bf059d720",
-            "versionInfo": "1.4.2",
+            "versionInfo": "1.4.3",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaData/PooledArrays.jl.git@v1.4.2",
+            "downloadLocation": "git+https://github.com/JuliaData/PooledArrays.jl.git@v1.4.3",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "0b9e669a3cba49320adb78fbf4419efe438abe2a"
+                "packageVerificationCodeValue": "bd35c781a2880a07163cc759b0c18a7bd6155d19"
             },
             "homepage": "https://github.com/JuliaData/PooledArrays.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -158,6 +164,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -179,18 +186,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "TranscodingStreams",
             "SPDXID": "SPDXRef-TranscodingStreams-3bb67fe8-82b1-5028-8e26-92a6c54297fa",
-            "versionInfo": "0.9.13",
+            "versionInfo": "0.10.2",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaIO/TranscodingStreams.jl.git@v0.9.13",
+            "downloadLocation": "git+https://github.com/JuliaIO/TranscodingStreams.jl.git@v0.10.2",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "e5a4c37d0a037ad678236a9ed999a71425c10156"
+                "packageVerificationCodeValue": "90cea81c962115f66159e9916778d46e84c92886"
             },
             "homepage": "https://github.com/JuliaIO/TranscodingStreams.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -200,18 +208,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "CodecZlib",
             "SPDXID": "SPDXRef-CodecZlib-944b1d66-785c-5afd-91f1-9de20f533193",
-            "versionInfo": "0.7.1",
+            "versionInfo": "0.7.3",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaIO/CodecZlib.jl.git@v0.7.1",
+            "downloadLocation": "git+https://github.com/JuliaIO/CodecZlib.jl.git@v0.7.3",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "ab8a05667650c6c0a413cc28f76dd205b86b5ffc"
+                "packageVerificationCodeValue": "ae8377bbecfd0d248b98ca17957297b9088eb603"
             },
             "homepage": "https://github.com/JuliaIO/CodecZlib.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -221,18 +230,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "OrderedCollections",
             "SPDXID": "SPDXRef-OrderedCollections-bac558e1-5e72-5ebc-8fee-abe8a469f55d",
-            "versionInfo": "1.6.0",
+            "versionInfo": "1.6.3",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaCollections/OrderedCollections.jl.git@v1.6.0",
+            "downloadLocation": "git+https://github.com/JuliaCollections/OrderedCollections.jl.git@v1.6.3",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "cd9c2abd323e6b7b028067faf5062878eca9f2b1"
+                "packageVerificationCodeValue": "b4c77ae026565dad5b95179d347a957cb1c164a7"
             },
             "homepage": "https://github.com/JuliaCollections/OrderedCollections.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -242,6 +252,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -263,6 +274,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -284,6 +296,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -305,18 +318,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "Tables",
             "SPDXID": "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c",
-            "versionInfo": "1.10.1",
+            "versionInfo": "1.11.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaData/Tables.jl.git@v1.10.1",
+            "downloadLocation": "git+https://github.com/JuliaData/Tables.jl.git@v1.11.1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "00fc38f6a0590390384f01b8b956f51a83a0c6ed"
+                "packageVerificationCodeValue": "231534f06e0abd7f3d9e29740a690486ca86f4aa"
             },
             "homepage": "https://github.com/JuliaData/Tables.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -326,18 +340,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "Compat",
             "SPDXID": "SPDXRef-Compat-34da2185-b29b-5c13-b0c7-acf172513d20",
-            "versionInfo": "4.6.1",
+            "versionInfo": "4.10.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaLang/Compat.jl.git@v4.6.1",
+            "downloadLocation": "git+https://github.com/JuliaLang/Compat.jl.git@v4.10.1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "2ea161fef134a0ccc6a6d7375f62eb01e2bfe922"
+                "packageVerificationCodeValue": "6e8746a0b5631a46908eb140105b8ee20f8ccc80"
             },
             "homepage": "https://github.com/JuliaLang/Compat.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -347,18 +362,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "FilePathsBase",
             "SPDXID": "SPDXRef-FilePathsBase-48062228-2e41-5def-b9a4-89aafe57970f",
-            "versionInfo": "0.9.20",
+            "versionInfo": "0.9.21",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/rofinn/FilePathsBase.jl.git@v0.9.20",
+            "downloadLocation": "git+https://github.com/rofinn/FilePathsBase.jl.git@v0.9.21",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "0907eb6554b48be734b00626b502e10ab98db095"
+                "packageVerificationCodeValue": "3d5a05fe51352a5540bfff9a5200f1daadcc9a31"
             },
             "homepage": "https://github.com/rofinn/FilePathsBase.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -368,18 +384,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "SentinelArrays",
             "SPDXID": "SPDXRef-SentinelArrays-91c51154-3ec4-41a3-a24f-3f23e20d615c",
-            "versionInfo": "1.3.18",
+            "versionInfo": "1.4.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaData/SentinelArrays.jl.git@v1.3.18",
+            "downloadLocation": "git+https://github.com/JuliaData/SentinelArrays.jl.git@v1.4.1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "7be26209081f03d31fc0a1cfbcd3a2152e135f82"
+                "packageVerificationCodeValue": "789b5c54c2390420f1042679e7853507f906e33c"
             },
             "homepage": "https://github.com/JuliaData/SentinelArrays.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -389,18 +406,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "CSV",
             "SPDXID": "SPDXRef-CSV-336ed68f-0bac-5ca0-87d4-7b16caf5d00b",
-            "versionInfo": "0.10.10",
+            "versionInfo": "0.10.11",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaData/CSV.jl.git@v0.10.10",
+            "downloadLocation": "git+https://github.com/JuliaData/CSV.jl.git@v0.10.11",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "58241ad99103bfedae453859a1379e382a184f55"
+                "packageVerificationCodeValue": "e2eef119bdf3aa65a4121adaa7fba06b46c817ec"
             },
             "homepage": "https://github.com/JuliaData/CSV.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -410,6 +428,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -431,18 +450,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "DataStructures",
             "SPDXID": "SPDXRef-DataStructures-864edb3b-99cc-5e75-8d2d-829cb0a9cfe8",
-            "versionInfo": "0.18.13",
+            "versionInfo": "0.18.15",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaCollections/DataStructures.jl.git@v0.18.13",
+            "downloadLocation": "git+https://github.com/JuliaCollections/DataStructures.jl.git@v0.18.15",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "f18b4a352c16b82fbe480e5b6ac2da6a5b47af9a"
+                "packageVerificationCodeValue": "bdaac673e4117bf2a8a5d9d013d4bfaa99870b34"
             },
             "homepage": "https://github.com/JuliaCollections/DataStructures.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -452,18 +472,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "SortingAlgorithms",
             "SPDXID": "SPDXRef-SortingAlgorithms-a2af1166-a08f-5f64-846c-94a0d3cef48c",
-            "versionInfo": "1.1.0",
+            "versionInfo": "1.2.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaCollections/SortingAlgorithms.jl.git@v1.1.0",
+            "downloadLocation": "git+https://github.com/JuliaCollections/SortingAlgorithms.jl.git@v1.2.1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "dbc4916fb45195b62d7a57b5e21601091624fb20"
+                "packageVerificationCodeValue": "734e4aaa438397cc1be329a1d245eaf7edea0771"
             },
             "homepage": "https://github.com/JuliaCollections/SortingAlgorithms.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -473,6 +494,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -494,6 +516,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -515,39 +538,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "SnoopPrecompile",
-            "SPDXID": "SPDXRef-SnoopPrecompile-66db9d55-30c0-4569-8b51-7e840670fc0c",
-            "versionInfo": "1.0.3",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/timholy/SnoopCompile.jl.git@v1.0.3",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "22907f95b04d3ab86e84303a3154b2b97efe94e1"
-            },
-            "homepage": "https://github.com/timholy/SnoopCompile.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "StringManipulation",
             "SPDXID": "SPDXRef-StringManipulation-892a3eda-7b42-436c-8928-eab12a02cf0e",
-            "versionInfo": "0.3.0",
+            "versionInfo": "0.3.4",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/ronisbr/StringManipulation.jl.git@v0.3.0",
+            "downloadLocation": "git+https://github.com/ronisbr/StringManipulation.jl.git@v0.3.4",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "41e9962902c10749f01e978ab68fbb8ce8f6bfd7"
+                "packageVerificationCodeValue": "85b507b872bc3607fb7e2ed8d10be1d6f6a322c6"
             },
             "homepage": "https://github.com/ronisbr/StringManipulation.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -557,27 +560,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Formatting",
-            "SPDXID": "SPDXRef-Formatting-59287772-0a20-5a39-b81b-1366585eb4c0",
-            "versionInfo": "0.4.2",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaIO/Formatting.jl.git@v0.4.2",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "1fb5a63d486fa5ef74c58d626adae8a143a3a7e2"
-            },
-            "homepage": "https://github.com/JuliaIO/Formatting.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -599,20 +582,21 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "LaTeXStrings",
             "SPDXID": "SPDXRef-LaTeXStrings-b964fa9f-0449-5b57-a5c2-d3ea65f4040f",
-            "versionInfo": "1.3.0",
+            "versionInfo": "1.3.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/stevengj/LaTeXStrings.jl.git@v1.3.0",
+            "downloadLocation": "git+https://github.com/JuliaStrings/LaTeXStrings.jl.git@v1.3.1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "a0ba6aa62b06177c171b71d3d1874fdff048e78e"
+                "packageVerificationCodeValue": "73ff8da3ef090d0ac8294c387b25ca4c9f137965"
             },
-            "homepage": "https://github.com/stevengj/LaTeXStrings.jl.git",
+            "homepage": "https://github.com/JuliaStrings/LaTeXStrings.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
             "licenseConcluded": "NOASSERTION",
             "licenseInfoFromFiles": [
@@ -620,6 +604,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -641,18 +626,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "PrettyTables",
             "SPDXID": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d",
-            "versionInfo": "2.2.4",
+            "versionInfo": "2.3.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/ronisbr/PrettyTables.jl.git@v2.2.4",
+            "downloadLocation": "git+https://github.com/ronisbr/PrettyTables.jl.git@v2.3.1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "85123a5f605fd538ca1694539b13978cd02b4047"
+                "packageVerificationCodeValue": "dc9f61f681a5585f4738d8edaae1278d9f60fcf6"
             },
             "homepage": "https://github.com/ronisbr/PrettyTables.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -662,18 +648,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "DataFrames",
             "SPDXID": "SPDXRef-DataFrames-a93c6f00-e57d-5684-b7b6-d8193f3e46c0",
-            "versionInfo": "1.5.0",
+            "versionInfo": "1.6.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaData/DataFrames.jl.git@v1.5.0",
+            "downloadLocation": "git+https://github.com/JuliaData/DataFrames.jl.git@v1.6.1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "c417018240ed7e9a3009394847493d13a21d136f"
+                "packageVerificationCodeValue": "bacd69a1c83d26836800b7ee5f7eab193c64bc7d"
             },
             "homepage": "https://github.com/JuliaData/DataFrames.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -683,6 +670,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -704,6 +692,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -725,18 +714,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "URIs",
             "SPDXID": "SPDXRef-URIs-5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4",
-            "versionInfo": "1.4.2",
+            "versionInfo": "1.5.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaWeb/URIs.jl.git@v1.4.2",
+            "downloadLocation": "git+https://github.com/JuliaWeb/URIs.jl.git@v1.5.1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "0aa8edf1802fd01e1fadca6c56155720b2ea8671"
+                "packageVerificationCodeValue": "904b3d1238fd9ee1b6176e6f48af3f8d3ac4286c"
             },
             "homepage": "https://github.com/JuliaWeb/URIs.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -746,18 +736,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "LoggingExtras",
             "SPDXID": "SPDXRef-LoggingExtras-e6f89c97-d47a-5376-807f-9c37f3926c36",
-            "versionInfo": "1.0.0",
+            "versionInfo": "1.0.3",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaLogging/LoggingExtras.jl.git@v1.0.0",
+            "downloadLocation": "git+https://github.com/JuliaLogging/LoggingExtras.jl.git@v1.0.3",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "1c8f29c722656fd7e8ec60bfa3d890afb3a1561f"
+                "packageVerificationCodeValue": "6162813cf16e38e703bb7cf03f05aa93cde4cdb4"
             },
             "homepage": "https://github.com/JuliaLogging/LoggingExtras.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -767,18 +758,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "ConcurrentUtilities",
             "SPDXID": "SPDXRef-ConcurrentUtilities-f0e56b4a-5159-44fe-b623-3e5288b988bb",
-            "versionInfo": "2.2.0",
+            "versionInfo": "2.3.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaServices/ConcurrentUtilities.jl.git@v2.2.0",
+            "downloadLocation": "git+https://github.com/JuliaServices/ConcurrentUtilities.jl.git@v2.3.0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "ac4b952451439efc8b1b7daccfd994a021675df5"
+                "packageVerificationCodeValue": "0ef5a492cff8f9308ff3a16732e0cb102f9104ad"
             },
             "homepage": "https://github.com/JuliaServices/ConcurrentUtilities.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -788,18 +780,41 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ExceptionUnwrapping",
+            "SPDXID": "SPDXRef-ExceptionUnwrapping-460bff9d-24e4-43bc-9d9f-a8973cb893f4",
+            "versionInfo": "0.1.10",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaServices/ExceptionUnwrapping.jl.git@v0.1.10",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "183ded3f1cd4301ccc2aff0f9f8f2e2ffdba8760"
+            },
+            "homepage": "https://github.com/JuliaServices/ExceptionUnwrapping.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "MbedTLS",
             "SPDXID": "SPDXRef-MbedTLS-739be429-bea8-5141-9913-cc70e7f3736d",
-            "versionInfo": "1.1.7",
+            "versionInfo": "1.1.9",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaLang/MbedTLS.jl.git@v1.1.7",
+            "downloadLocation": "git+https://github.com/JuliaLang/MbedTLS.jl.git@v1.1.9",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "bcafc003832f2fecd91fdd651c608e03e3b13da8"
+                "packageVerificationCodeValue": "18eb5c751d9831b6e25b69f0a7b2ea3b8edcc924"
             },
             "homepage": "https://github.com/JuliaLang/MbedTLS.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -809,18 +824,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "JLLWrappers",
             "SPDXID": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-            "versionInfo": "1.4.1",
+            "versionInfo": "1.5.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaPackaging/JLLWrappers.jl.git@v1.4.1",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/JLLWrappers.jl.git@v1.5.0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "a2ad6d2bf15070059c3df758bd3ea502676b09af"
+                "packageVerificationCodeValue": "0549f1c88d0415b1e8da49263088c9498d847ffd"
             },
             "homepage": "https://github.com/JuliaPackaging/JLLWrappers.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -830,18 +846,43 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "OpenSSL",
+            "SPDXID": "SPDXRef-779e94a792b089936ee92f4122727d8f76929cfb",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/OpenSSL_jll.jl/releases/download/OpenSSL-v3.0.12+0/OpenSSL.v3.0.12.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "fd71aa619dbf7b63b4e2b791474fa037f4de348560f2e0a7b8e5819e45dc3f91"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "OpenSSL_jll",
             "SPDXID": "SPDXRef-OpenSSL_jll-458c3c95-2e84-50aa-8efc-19380b2a3a95",
-            "versionInfo": "1.1.20+0",
+            "versionInfo": "3.0.12+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/OpenSSL_jll.jl.git@v1.1.20+0",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/OpenSSL_jll.jl.git@v3.0.12+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "eb0692ba59525d75cb04c5d625fc15376fa500fe"
+                "packageVerificationCodeValue": "ba9b4eeb3819538c026ca6b71ce51a7d8800b6f5"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/OpenSSL_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -851,18 +892,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "BitFlags",
             "SPDXID": "SPDXRef-BitFlags-d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35",
-            "versionInfo": "0.1.7",
+            "versionInfo": "0.1.8",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/jmert/BitFlags.jl.git@v0.1.7",
+            "downloadLocation": "git+https://github.com/jmert/BitFlags.jl.git@v0.1.8",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "8e6d8a6c128c1e15c1f3f32e8291b47ccc58a00c"
+                "packageVerificationCodeValue": "5f7f66843dd9a3e41330e693c74f5dd6af327400"
             },
             "homepage": "https://github.com/jmert/BitFlags.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -872,6 +914,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -893,6 +936,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -914,18 +958,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "HTTP",
             "SPDXID": "SPDXRef-HTTP-cd3eb016-35fb-5094-929b-558a96fad6f3",
-            "versionInfo": "1.9.4",
+            "versionInfo": "1.10.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaWeb/HTTP.jl.git@v1.9.4",
+            "downloadLocation": "git+https://github.com/JuliaWeb/HTTP.jl.git@v1.10.1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "7eb6cb40c991901b127f58aac01ae9736683d525"
+                "packageVerificationCodeValue": "f4b495a8faeafe3599211880e373dfbc9984aba2"
             },
             "homepage": "https://github.com/JuliaWeb/HTTP.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -935,7 +980,54 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "DelimitedFiles",
+            "SPDXID": "SPDXRef-DelimitedFiles-8bb1440f-4735-579b-a4ab-409b98df4dab",
+            "versionInfo": "1.9.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaData/DelimitedFiles.jl.git@v1.9.1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "1c3158a25fb09ce163b5c66b41bb1fc4ad6e6505"
+            },
+            "homepage": "https://github.com/JuliaData/DelimitedFiles.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Bzip2",
+            "SPDXID": "SPDXRef-2a86ef020f132332b2f4be2fb40912cc7df5da29",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Bzip2_jll.jl/releases/download/Bzip2-v1.0.8+0/Bzip2.v1.0.8.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "02bb57e59658a0c8cff431b69217383d42d99c8729822348600d1dee7eeec6db"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "Bzip2_jll",
@@ -956,6 +1048,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -977,18 +1070,43 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "FreeType2",
+            "SPDXID": "SPDXRef-c65e07e3da4f1bf519bc432389dbbd61df320457",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/FreeType2_jll.jl/releases/download/FreeType2-v2.13.1+0/FreeType2.v2.13.1.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "537cee2c03ba6d3d7047f6021cf0830f863c2916097e203574246463cf3a3118"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "FreeType2_jll",
             "SPDXID": "SPDXRef-FreeType2_jll-d7e528f0-a631-5988-bf34-fe36492bcfd7",
-            "versionInfo": "2.10.4+0",
+            "versionInfo": "2.13.1+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/FreeType2_jll.jl.git@v2.10.4+0",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/FreeType2_jll.jl.git@v2.13.1+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "7e07a45d03e00a914c9814d4b09c1b249ce3123c"
+                "packageVerificationCodeValue": "bf4b9a7d6cefbf1d8c9a33df32317556e2eab3da"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/FreeType2_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -998,18 +1116,43 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Expat",
+            "SPDXID": "SPDXRef-4ec62d729213a748d2300dd0832ebe8ed2292093",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Expat_jll.jl/releases/download/Expat-v2.5.0+0/Expat.v2.5.0.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "cbf3634506a0afe598015c545ec371a57dd8c23d2d5a50b8ce58e5fb9ed9d0be"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "Expat_jll",
             "SPDXID": "SPDXRef-Expat_jll-2e619515-83b5-522b-bb60-26c02a35a201",
-            "versionInfo": "2.4.8+0",
+            "versionInfo": "2.5.0+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Expat_jll.jl.git@v2.4.8+0",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Expat_jll.jl.git@v2.5.0+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "75b919c2ca5230f6886bb99b83af81bfc1a8b4bb"
+                "packageVerificationCodeValue": "07591c049292b80fcbff484c9d1c17404e05e6a9"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/Expat_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -1019,7 +1162,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Fontconfig",
+            "SPDXID": "SPDXRef-e6b9fb44029423f5cd69e0cbbff25abcc4b32a8f",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Fontconfig_jll.jl/releases/download/Fontconfig-v2.13.93+0/Fontconfig.v2.13.93.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "53d31fd7ac68cf67cfe3f7b98301b35769bfcd443fca7dc02a60f6f869bdb3d1"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "Fontconfig_jll",
@@ -1040,18 +1208,89 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "LLVMOpenMP",
+            "SPDXID": "SPDXRef-10b2b258c07d7a76b2e3331f1ed70d8a8eb6d71c",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/LLVMOpenMP_jll.jl/releases/download/LLVMOpenMP-v15.0.7+0/LLVMOpenMP.v15.0.7.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "4de924458b5f31d0b86d27c4cec72952a6900b7f669862754cf8eac91e77d5d2"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "LLVMOpenMP_jll",
+            "SPDXID": "SPDXRef-LLVMOpenMP_jll-1d63c593-3942-5779-bab2-d838dc0a180e",
+            "versionInfo": "15.0.7+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/LLVMOpenMP_jll.jl.git@v15.0.7+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "d67322950e4b7419e41f1852e35bddbdb467593f"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/LLVMOpenMP_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Pixman",
+            "SPDXID": "SPDXRef-9a76a401f82e0e3cafce618fb8d2d5c307ab2836",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Pixman_jll.jl/releases/download/Pixman-v0.42.2+0/Pixman.v0.42.2.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "991ac084b55920bca2bb66e5fd4dc2ad81906fb3465fa0f4c70575bec0ac5633"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "Pixman_jll",
             "SPDXID": "SPDXRef-Pixman_jll-30392449-352a-5448-841d-b1acce4e97dc",
-            "versionInfo": "0.40.1+0",
+            "versionInfo": "0.42.2+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Pixman_jll.jl.git@v0.40.1+0",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Pixman_jll.jl.git@v0.42.2+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "f2dbac3b0d7c47cfed02e0235ef7d8b18b468e5c"
+                "packageVerificationCodeValue": "a37f31862acb9153b7518cc656f820241a2faf8e"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/Pixman_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -1061,7 +1300,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "LAME",
+            "SPDXID": "SPDXRef-413111420faa4e2aeaa383c075eaa213402d939c",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/LAME_jll.jl/releases/download/LAME-v3.100.1+0/LAME.v3.100.1.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "e6d944afa3d1903865e58e6523b09c4a47c8c337cf38a33a2ee64e9edcd129e2"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "LAME_jll",
@@ -1082,7 +1346,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Opus",
+            "SPDXID": "SPDXRef-4609432e7098d8434a7a4c7876dd5b9e09b2a5e7",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Opus_jll.jl/releases/download/Opus-v1.3.2+0/Opus.v1.3.2.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "3c75ed2907000c3c961e615eb28a1b9a4dc1932da7f73c3cc1d7d701b8c06a37"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "Opus_jll",
@@ -1103,7 +1392,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "FriBidi",
+            "SPDXID": "SPDXRef-df3881e810714d6a09467fe85a6fde79385fe702",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/FriBidi_jll.jl/releases/download/FriBidi-v1.0.10+0/FriBidi.v1.0.10.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "48e5bbeeb0d597b4e06e3d5236292353f5838813dccacb4e0bbbf63163674eaa"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "FriBidi_jll",
@@ -1124,7 +1438,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "x264",
+            "SPDXID": "SPDXRef-0db9c3f6cf936a0da49e2ba954ba3e10bed6ad72",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/x264_jll.jl/releases/download/x264-v2021.5.5+0/x264.v2021.5.5.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "3b31497f92e41c3edce47e6d21284526febd30537aa34c2a1a81e55f6943548d"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "x264_jll",
@@ -1145,7 +1484,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "libaom",
+            "SPDXID": "SPDXRef-c325a23bc1f6521474cef5f634f18c8ab311bb02",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/libaom_jll.jl/releases/download/libaom-v3.4.0+0/libaom.v3.4.0.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "4ccbe4bc1a762a215842f209d97a30a0cd00aca9fda732af0eafdc099a8be857"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "libaom_jll",
@@ -1166,7 +1530,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Ogg",
+            "SPDXID": "SPDXRef-ca2831bf6edc5088aec5b329ea98364951d6cad0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Ogg_jll.jl/releases/download/Ogg-v1.3.5+1/Ogg.v1.3.5.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "c9a8254525e0f2da318fa259b344d5cbb648e0ae05e0f7263a2ad8f2465bc7c2"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "Ogg_jll",
@@ -1187,7 +1576,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "libvorbis",
+            "SPDXID": "SPDXRef-3fe6bf926e57cc4be598151cd40832221de2e894",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/libvorbis_jll.jl/releases/download/libvorbis-v1.3.7+1/libvorbis.v1.3.7.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "23a5711a3fa354caa7dd614b426a2d8115e6ecce0c15278b70d05808bae30565"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "libvorbis_jll",
@@ -1208,7 +1622,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "x265",
+            "SPDXID": "SPDXRef-1a7e22e66b523d9cb884cf85c3ec065b5fb3e5c3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/x265_jll.jl/releases/download/x265-v3.5.0+0/x265.v3.5.0.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "076e909e7a78227b9da9a2f261613859f30f0d6cf6fd6afad1d232909e245edf"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "x265_jll",
@@ -1229,7 +1668,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Libffi",
+            "SPDXID": "SPDXRef-5b338c8fa90c05e6faea86e54d2996cca76cfbbe",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Libffi_jll.jl/releases/download/Libffi-v3.2.2+1/Libffi.v3.2.2.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "ca0155259396ecf3077bd721e15f8f5b7ef0ddc984539467dd814b79688581f1"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "Libffi_jll",
@@ -1250,18 +1714,43 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Libiconv",
+            "SPDXID": "SPDXRef-92b949e2f3a66439c69a8d334fc95810fbd9df9b",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Libiconv_jll.jl/releases/download/Libiconv-v1.17.0+0/Libiconv.v1.17.0.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "608336f578104c2b556d5c6cbfe1d00bc1ec15b863659f2b72d252138b28d7ad"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "Libiconv_jll",
             "SPDXID": "SPDXRef-Libiconv_jll-94ce4f54-9a6c-5748-9c1c-f9c7231a4531",
-            "versionInfo": "1.16.1+2",
+            "versionInfo": "1.17.0+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Libiconv_jll.jl.git@v1.16.1+2",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Libiconv_jll.jl.git@v1.17.0+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "f191ea65726d010294bfe9a163828ca5017c068e"
+                "packageVerificationCodeValue": "dbebcef5e82d55996ac6698bb550938a16f688ec"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/Libiconv_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -1271,18 +1760,43 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "XML2",
+            "SPDXID": "SPDXRef-d18fd9a0903c01ba831674a057a5ef7caf6aeec6",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/XML2_jll.jl/releases/download/XML2-v2.12.2+0/XML2.v2.12.2.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "f91a1e3d2e8da9e41740df6cf9559cd484c1bbe12f9d5d1f0cd61c70868051c3"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "XML2_jll",
             "SPDXID": "SPDXRef-XML2_jll-02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a",
-            "versionInfo": "2.10.3+0",
+            "versionInfo": "2.12.2+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/XML2_jll.jl.git@v2.10.3+0",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/XML2_jll.jl.git@v2.12.2+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "b04abfd0041d489384705940277258e5e127da6d"
+                "packageVerificationCodeValue": "c992f8689c562ea98ead951f80891ed1e24f435b"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/XML2_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -1292,7 +1806,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Libgpg_error",
+            "SPDXID": "SPDXRef-a110b2aa0a23e2f4498373c088a95ae6ba07b7f7",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Libgpg_error_jll.jl/releases/download/Libgpg_error-v1.42.0+0/Libgpg_error.v1.42.0.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "cfd0266fbcc5ac11559e6f227c4d09ac01064f8d7acc93e7ee2c8d4dc936cde2"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "Libgpg_error_jll",
@@ -1313,7 +1852,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Libgcrypt",
+            "SPDXID": "SPDXRef-58860383d52098836448ae8a8d1247482bccda22",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Libgcrypt_jll.jl/releases/download/Libgcrypt-v1.8.7+0/Libgcrypt.v1.8.7.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "0b05a33233a7a7b6669002655d84a5ef8718fe2fbeb8d8340abc48d62b635070"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "Libgcrypt_jll",
@@ -1334,7 +1898,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "XSLT",
+            "SPDXID": "SPDXRef-40962d05f37e788d1c44ead73e045964323782bb",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/XSLT_jll.jl/releases/download/XSLT-v1.1.34+0/XSLT.v1.1.34.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "07dc667c14caf5d0c7844341ed9c43b2c71848adcc2fb82e680c7c99e234b1ea"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "XSLT_jll",
@@ -1355,18 +1944,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "Xorg_libXau_jll",
             "SPDXID": "SPDXRef-Xorg_libXau_jll-0c0b7dd1-d40b-584c-a123-a41640f87eec",
-            "versionInfo": "1.0.9+4",
+            "versionInfo": "1.0.11+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_libXau_jll.jl.git@v1.0.9+4",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_libXau_jll.jl.git@v1.0.11+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "c9a93f71092cfa6f7ab8c6b69998202040915ba4"
+                "packageVerificationCodeValue": "ecc1fffa24e4a1f58ef67bb8852d927264939c66"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_libXau_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -1376,18 +1966,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "Xorg_libpthread_stubs_jll",
             "SPDXID": "SPDXRef-Xorg_libpthread_stubs_jll-14d82f49-176c-5ed1-bb49-ad3f5cbd8c74",
-            "versionInfo": "0.1.0+3",
+            "versionInfo": "0.1.1+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_libpthread_stubs_jll.jl.git@v0.1.0+3",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_libpthread_stubs_jll.jl.git@v0.1.1+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "6fa01b442518dc689c97e79787ed5f7f9c8ef631"
+                "packageVerificationCodeValue": "7d338c5536783d45c9edc072164ab00fc7643248"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_libpthread_stubs_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -1397,18 +1988,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "Xorg_libXdmcp_jll",
             "SPDXID": "SPDXRef-Xorg_libXdmcp_jll-a3789734-cfe1-5b06-b2d0-1dd0d9d62d05",
-            "versionInfo": "1.1.3+4",
+            "versionInfo": "1.1.4+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_libXdmcp_jll.jl.git@v1.1.3+4",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_libXdmcp_jll.jl.git@v1.1.4+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "c8b130f96c10f622eb56e249869661760baf5881"
+                "packageVerificationCodeValue": "248b80316c0b6bfe1ceebd72466847dbea99aa17"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_libXdmcp_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -1418,18 +2010,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "Xorg_libxcb_jll",
             "SPDXID": "SPDXRef-Xorg_libxcb_jll-c7cfdc94-dc32-55de-ac96-5a1b8d977c5b",
-            "versionInfo": "1.13.0+3",
+            "versionInfo": "1.15.0+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_libxcb_jll.jl.git@v1.13.0+3",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_libxcb_jll.jl.git@v1.15.0+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "1a993956165b4fdae13d9f85f6445ee9a680b029"
+                "packageVerificationCodeValue": "3f64a15076d4e6ab1dbc9371c46caa1653724659"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_libxcb_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -1439,18 +2032,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "Xorg_xtrans_jll",
             "SPDXID": "SPDXRef-Xorg_xtrans_jll-c5fb5394-a638-5e4d-96e5-b29de1b5cf10",
-            "versionInfo": "1.4.0+3",
+            "versionInfo": "1.5.0+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xtrans_jll.jl.git@v1.4.0+3",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xtrans_jll.jl.git@v1.5.0+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "23b70c2043b5a4e1588b9bb3f6415d147a52b9e2"
+                "packageVerificationCodeValue": "d7e7c09fed558824e9931d80587cada733fdfb51"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xtrans_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -1460,18 +2054,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "Xorg_libX11_jll",
             "SPDXID": "SPDXRef-Xorg_libX11_jll-4f6342f7-b3d2-589e-9d20-edeb45f2b2bc",
-            "versionInfo": "1.6.9+4",
+            "versionInfo": "1.8.6+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_libX11_jll.jl.git@v1.6.9+4",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_libX11_jll.jl.git@v1.8.6+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "6c5da0e81611827431b2841eb40d72bdd9b88e46"
+                "packageVerificationCodeValue": "ffc23a5a71a0eb60d25039af286d315000a317c8"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_libX11_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -1481,6 +2076,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -1502,7 +2098,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Gettext",
+            "SPDXID": "SPDXRef-9410bad2635eda2239b4a72ba4316c4aa8f5b76e",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Gettext_jll.jl/releases/download/Gettext-v0.21.0+0/Gettext.v0.21.0.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "f65b5bf48c5b377d25b2a84b475f69a635e8d901b1fd5644cdbcbf160bb14d50"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "Gettext_jll",
@@ -1523,6 +2144,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -1544,18 +2166,43 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Glib",
+            "SPDXID": "SPDXRef-95f332911a8dd5ab82620ba58c217193bd0d515d",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Glib_jll.jl/releases/download/Glib-v2.76.5+0/Glib.v2.76.5.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "9634924d2ce64a372301a6ed5695bf2a38bfd928085818a7c04d2b43c810a47c"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "Glib_jll",
             "SPDXID": "SPDXRef-Glib_jll-7746bdde-850d-59dc-9ae8-88ece973131d",
-            "versionInfo": "2.74.0+2",
+            "versionInfo": "2.76.5+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Glib_jll.jl.git@v2.74.0+2",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Glib_jll.jl.git@v2.76.5+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "2f123936d03386e495614d80f0ddd8eed05f9271"
+                "packageVerificationCodeValue": "188d70ec853a9d3724cd34afa055e8958ed9769c"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/Glib_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -1565,6 +2212,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -1586,18 +2234,43 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "libpng",
+            "SPDXID": "SPDXRef-e8b1e36798f9659162a3c55c9f0e772c685de558",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/libpng_jll.jl/releases/download/libpng-v1.6.40+0/libpng.v1.6.40.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "89eda83ecbfea1a570a2979160cd7dc8cc71979d9f2d0c8c60e0eb26a61f5713"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "libpng_jll",
             "SPDXID": "SPDXRef-libpng_jll-b53b4c65-9356-5827-b1ea-8c7a1a84506f",
-            "versionInfo": "1.6.38+0",
+            "versionInfo": "1.6.40+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/libpng_jll.jl.git@v1.6.38+0",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/libpng_jll.jl.git@v1.6.40+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "3961370b8ca606cacc90e50c08752082a98fd880"
+                "packageVerificationCodeValue": "e39d777b3d232c680ae0a74555998381c2175847"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/libpng_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -1607,7 +2280,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "LZO",
+            "SPDXID": "SPDXRef-b2108f561a8812e376eb80e71a24a3678a24d231",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/LZO_jll.jl/releases/download/LZO-v2.10.1+0/LZO.v2.10.1.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "ccddd845866f84aba3e16c243dee68568dabaf29aee6b136f8b725fe1a3f98f3"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "LZO_jll",
@@ -1628,7 +2326,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Cairo",
+            "SPDXID": "SPDXRef-ada2a202928dd4cb2fc4bd18c4efa9d5455ec742",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Cairo_jll.jl/releases/download/Cairo-v1.16.1+0/Cairo.v1.16.1.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "eadb8d89c399a6e7022603329ca30dd35744bd69b5d6f1ce1704976e93e9a187"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "Cairo_jll",
@@ -1649,7 +2372,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Graphite2",
+            "SPDXID": "SPDXRef-3b3d0bcaf14a9b239a4f4dc20ef7b9e63030a47e",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Graphite2_jll.jl/releases/download/Graphite2-v1.3.14+0/Graphite2.v1.3.14.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "c1054fc98ff4b06b5f1cb052d39a5d7a9caf859ba74391094fcd6cea17d29793"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "Graphite2_jll",
@@ -1670,7 +2418,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "HarfBuzz",
+            "SPDXID": "SPDXRef-abf161ac3d4df76ae74bbf5432b7e061b3876236",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/HarfBuzz_jll.jl/releases/download/HarfBuzz-v2.8.1+1/HarfBuzz.v2.8.1.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "2400903916f1e8671ff6c80e36d9867e543f6b05e2286c3e2c51dd6687927d83"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "HarfBuzz_jll",
@@ -1691,7 +2464,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "libass",
+            "SPDXID": "SPDXRef-4260cf51a368d8e305a5de3669e32539e1e6cc72",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/libass_jll.jl/releases/download/libass-v0.15.1+0/libass.v0.15.1.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "c4543b0df52e6d88608fc291f794953820f1b2bc5798b238d562155f082f3d03"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "libass_jll",
@@ -1712,7 +2510,32 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "libfdk_aac",
+            "SPDXID": "SPDXRef-fc7ba632b72ce7d852c1924aa2bbfe244a71c780",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/libfdk_aac_jll.jl/releases/download/libfdk_aac-v2.0.2+0/libfdk_aac.v2.0.2.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "8020844d278fe3aef4c43469a8724ead9cc3047afe03f52ee31ab9ada8134734"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "libfdk_aac_jll",
@@ -1733,18 +2556,43 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "FFMPEG",
+            "SPDXID": "SPDXRef-6095fcd268ea712c0f786f5ff1a45bf0eb7b005e",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/FFMPEG_jll.jl/releases/download/FFMPEG-v4.4.4+1/FFMPEG.v4.4.4.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "bc4cdafe784b6350dfd5edede873978fbd645938d5fb8598b657ce556085cfb5"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "FFMPEG_jll",
             "SPDXID": "SPDXRef-FFMPEG_jll-b22a6f82-2f65-5046-a5b2-351ab43fb4e5",
-            "versionInfo": "4.4.2+2",
+            "versionInfo": "4.4.4+1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/FFMPEG_jll.jl.git@v4.4.2+2",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/FFMPEG_jll.jl.git@v4.4.4+1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "560608c40da18db86dd9b6952d89fde5d38a66ff"
+                "packageVerificationCodeValue": "98f6a05ed5a0cf149e41661d3de98a67baed6469"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/FFMPEG_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -1754,18 +2602,43 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "JpegTurbo",
+            "SPDXID": "SPDXRef-b80d54484d815d1ace4cb475d53da633579d7d92",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/JpegTurbo_jll.jl/releases/download/JpegTurbo-v3.0.1+0/JpegTurbo.v3.0.1.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "3b7c4a77ce40f12d256d29a349ff91d01b16f4691c671771b7551121e0a92214"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "JpegTurbo_jll",
             "SPDXID": "SPDXRef-JpegTurbo_jll-aacddb02-875f-59d6-b918-886e6ef4fbf8",
-            "versionInfo": "2.1.91+0",
+            "versionInfo": "3.0.1+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/JpegTurbo_jll.jl.git@v2.1.91+0",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/JpegTurbo_jll.jl.git@v3.0.1+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "f546b8fec3c7be6bfbeaab14c3d81d970bfec55a"
+                "packageVerificationCodeValue": "3ac833eccf9b42ab70adb7dcd9b1c902964dffa4"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/JpegTurbo_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -1775,6 +2648,191 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "LERC",
+            "SPDXID": "SPDXRef-b450526929615030746974fd622effa333c2c87a",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/LERC_jll.jl/releases/download/LERC-v3.0.0+1/LERC.v3.0.0.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "3ccb670b1c9e0bdab7973783fd90d687f94652a1baefb20d7c2fc7ace518b97a"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "LERC_jll",
+            "SPDXID": "SPDXRef-LERC_jll-88015f11-f218-50d7-93a8-a6af411a945d",
+            "versionInfo": "3.0.0+1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/LERC_jll.jl.git@v3.0.0+1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "d141d4456ec919ea4cde093dd7c11eb7cc617864"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/LERC_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "XZ",
+            "SPDXID": "SPDXRef-8f5f66cdbf511f7192128eedfe66211271783733",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/XZ_jll.jl/releases/download/XZ-v5.4.5+0/XZ.v5.4.5.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "1b7d9111c62eaae7f346bffe22d2de1d547cbbe317a5af320310fa6503435333"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "XZ_jll",
+            "SPDXID": "SPDXRef-XZ_jll-ffd25f8a-64ca-5728-b0f7-c24cf3aae800",
+            "versionInfo": "5.4.5+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/XZ_jll.jl.git@v5.4.5+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "58a353eccdbd82559b99f7292fd3af1c50216dfe"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/XZ_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Zstd",
+            "SPDXID": "SPDXRef-9a9f59eab237f7454fee1d6ab112a254032540b7",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Zstd_jll.jl/releases/download/Zstd-v1.5.5+0/Zstd.v1.5.5.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "764066f83bb76b355ea264f8dede8ec7fae27e31e0e8d6a927dd330394f1695a"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "Zstd_jll",
+            "SPDXID": "SPDXRef-Zstd_jll-3161d3a3-bdf6-5164-811a-617609db77b4",
+            "versionInfo": "1.5.5+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Zstd_jll.jl.git@v1.5.5+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "fa20ebb870e0a1ad2d66b8fb9bf771305a8bee08"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Zstd_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Libtiff",
+            "SPDXID": "SPDXRef-2107e7bc404f11b178cb9724cb371ef704995727",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Libtiff_jll.jl/releases/download/Libtiff-v4.5.1+1/Libtiff.v4.5.1.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "c77cb348174e1a6ba9c6607c8965bc524ac2c89210e8f39a7b06e8280af0d032"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "Libtiff_jll",
+            "SPDXID": "SPDXRef-Libtiff_jll-89763e89-9b03-5906-acba-b20f662cd828",
+            "versionInfo": "4.5.1+1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Libtiff_jll.jl.git@v4.5.1+1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "58f9688b5b30531476c4d52be6e34c7cd0b1f287"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Libtiff_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -1796,321 +2854,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Xorg_xcb_util_jll",
-            "SPDXID": "SPDXRef-Xorg_xcb_util_jll-2def613f-5ad1-5310-b15b-b15d46f528f5",
-            "versionInfo": "0.4.0+1",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_jll.jl.git@v0.4.0+1",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "cb1c09925bb103717736c072c00cd0c324bd615c"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Xorg_xcb_util_image_jll",
-            "SPDXID": "SPDXRef-Xorg_xcb_util_image_jll-12413925-8142-5f55-bb0e-6d7ca50bb09b",
-            "versionInfo": "0.4.0+1",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_image_jll.jl.git@v0.4.0+1",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "3c8b24223fe4dac74fcb4d1e915fb2c874cf12e3"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_image_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Xorg_libxkbfile_jll",
-            "SPDXID": "SPDXRef-Xorg_libxkbfile_jll-cc61e674-0454-545c-8b26-ed2c68acab7a",
-            "versionInfo": "1.1.0+4",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_libxkbfile_jll.jl.git@v1.1.0+4",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "ef96ad0d6d769a5565dd79bee9609686d3be06c3"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_libxkbfile_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Xorg_xkbcomp_jll",
-            "SPDXID": "SPDXRef-Xorg_xkbcomp_jll-35661453-b289-5fab-8a00-3d9160c6a3a4",
-            "versionInfo": "1.4.2+4",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xkbcomp_jll.jl.git@v1.4.2+4",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "b832774a4d4cee08e27993fe86ed232968885b86"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xkbcomp_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Xorg_xkeyboard_config_jll",
-            "SPDXID": "SPDXRef-Xorg_xkeyboard_config_jll-33bec58e-1273-512f-9401-5d533626f822",
-            "versionInfo": "2.27.0+4",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xkeyboard_config_jll.jl.git@v2.27.0+4",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "487567ff4c4fc96f775811a6abecb1090e0349dd"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xkeyboard_config_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Wayland_jll",
-            "SPDXID": "SPDXRef-Wayland_jll-a2964d1f-97da-50d4-b82a-358c7fce9d89",
-            "versionInfo": "1.21.0+0",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Wayland_jll.jl.git@v1.21.0+0",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "8c042dd21303ce6a80e4a9bd504bcd70424305b7"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/Wayland_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Wayland_protocols_jll",
-            "SPDXID": "SPDXRef-Wayland_protocols_jll-2381bf8a-dfd0-557d-9999-79630e7b1b91",
-            "versionInfo": "1.25.0+0",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Wayland_protocols_jll.jl.git@v1.25.0+0",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "2f8d369369250f88bcf8c20a10fdbc8e78fbeabb"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/Wayland_protocols_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "xkbcommon_jll",
-            "SPDXID": "SPDXRef-xkbcommon_jll-d8fb68d0-12a3-5cfd-a85a-d49703b185fd",
-            "versionInfo": "1.4.1+0",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/xkbcommon_jll.jl.git@v1.4.1+0",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "01acfca8ca9962f5aba62a1cac9f09de70b94f54"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/xkbcommon_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Xorg_xcb_util_wm_jll",
-            "SPDXID": "SPDXRef-Xorg_xcb_util_wm_jll-c22f9ab0-d5fe-5066-847c-f4bb1cd4e361",
-            "versionInfo": "0.4.1+1",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_wm_jll.jl.git@v0.4.1+1",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "2205b9c9808908bb25643cba13baee7516f35f94"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_wm_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Xorg_xcb_util_renderutil_jll",
-            "SPDXID": "SPDXRef-Xorg_xcb_util_renderutil_jll-0d47668e-0667-5a69-a72c-f761630bfb7e",
-            "versionInfo": "0.3.9+1",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_renderutil_jll.jl.git@v0.3.9+1",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "4ede5a3e816dd956841262e9382b89f986cb6cac"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_renderutil_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Xorg_xcb_util_keysyms_jll",
-            "SPDXID": "SPDXRef-Xorg_xcb_util_keysyms_jll-975044d2-76e6-5fbe-bf08-97ce7c6574c7",
-            "versionInfo": "0.4.0+1",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_keysyms_jll.jl.git@v0.4.0+1",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "f9318a072527fec2a7fa9c5351fd0bb469dea62b"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_keysyms_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Qt5Base_jll",
-            "SPDXID": "SPDXRef-Qt5Base_jll-ea2cea3b-5b76-57ae-a6ef-0a8af62496e1",
-            "versionInfo": "5.15.3+2",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Qt5Base_jll.jl.git@v5.15.3+2",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "7eae3002ac61f79aedf34b541bb78aec3f543309"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/Qt5Base_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "LERC_jll",
-            "SPDXID": "SPDXRef-LERC_jll-88015f11-f218-50d7-93a8-a6af411a945d",
-            "versionInfo": "3.0.0+1",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/LERC_jll.jl.git@v3.0.0+1",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "d141d4456ec919ea4cde093dd7c11eb7cc617864"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/LERC_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Zstd_jll",
-            "SPDXID": "SPDXRef-Zstd_jll-3161d3a3-bdf6-5164-811a-617609db77b4",
-            "versionInfo": "1.5.5+0",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Zstd_jll.jl.git@v1.5.5+0",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "fa20ebb870e0a1ad2d66b8fb9bf771305a8bee08"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/Zstd_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Libtiff_jll",
-            "SPDXID": "SPDXRef-Libtiff_jll-89763e89-9b03-5906-acba-b20f662cd828",
-            "versionInfo": "4.4.0+0",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Libtiff_jll.jl.git@v4.4.0+0",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "c1520536d5697abf264eb5df01db83bea3eaceab"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/Libtiff_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -2132,6 +2876,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -2153,6 +2898,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -2174,6 +2920,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -2195,6 +2942,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -2216,18 +2964,43 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "GLFW",
+            "SPDXID": "SPDXRef-8dfccc7f1aa9d156f12a6e7db599014b805b11f2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/GLFW_jll.jl/releases/download/GLFW-v3.3.9+0/GLFW.v3.3.9.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "029dd0f914d55bf707958ea086fb15719c8cea69a9e00834d3aedaef35477ecf"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "GLFW_jll",
             "SPDXID": "SPDXRef-GLFW_jll-0656b61e-2033-5cc2-a64a-77c0f6c09b89",
-            "versionInfo": "3.3.8+0",
+            "versionInfo": "3.3.9+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/GLFW_jll.jl.git@v3.3.8+0",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/GLFW_jll.jl.git@v3.3.9+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "500da8ae0a06ad334a06f337371b9bd613482ea3"
+                "packageVerificationCodeValue": "ac87c9e97162afa5c1262ebb6cf70704fe1d497c"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/GLFW_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -2237,18 +3010,645 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Xorg_xcb_util_jll",
+            "SPDXID": "SPDXRef-Xorg_xcb_util_jll-2def613f-5ad1-5310-b15b-b15d46f528f5",
+            "versionInfo": "0.4.0+1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_jll.jl.git@v0.4.0+1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "cb1c09925bb103717736c072c00cd0c324bd615c"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Xorg_xcb_util_image_jll",
+            "SPDXID": "SPDXRef-Xorg_xcb_util_image_jll-12413925-8142-5f55-bb0e-6d7ca50bb09b",
+            "versionInfo": "0.4.0+1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_image_jll.jl.git@v0.4.0+1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "3c8b24223fe4dac74fcb4d1e915fb2c874cf12e3"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_image_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Xorg_libxkbfile_jll",
+            "SPDXID": "SPDXRef-Xorg_libxkbfile_jll-cc61e674-0454-545c-8b26-ed2c68acab7a",
+            "versionInfo": "1.1.2+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_libxkbfile_jll.jl.git@v1.1.2+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "3a136b76a172cf9993361f5b431d761c856f2812"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_libxkbfile_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Xorg_xkbcomp_jll",
+            "SPDXID": "SPDXRef-Xorg_xkbcomp_jll-35661453-b289-5fab-8a00-3d9160c6a3a4",
+            "versionInfo": "1.4.6+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xkbcomp_jll.jl.git@v1.4.6+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "30ef7c7d919d8fa09e1d5dfd7162cef58fc005d6"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xkbcomp_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Xorg_xkeyboard_config",
+            "SPDXID": "SPDXRef-f8b49c7c45b400e3f5c4002d19645d4b88712c0c",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Xorg_xkeyboard_config_jll.jl/releases/download/Xorg_xkeyboard_config-v2.39.0+0/Xorg_xkeyboard_config.v2.39.0.any.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "44967eed2c0f1966c5e0e8f34b952793b5d53b5785c9d6c89cbfb6315cb2b847"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "Xorg_xkeyboard_config_jll",
+            "SPDXID": "SPDXRef-Xorg_xkeyboard_config_jll-33bec58e-1273-512f-9401-5d533626f822",
+            "versionInfo": "2.39.0+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xkeyboard_config_jll.jl.git@v2.39.0+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "82d2be08d6974f99258ada68529f5fc0c2c94bf8"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xkeyboard_config_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "EpollShim_jll",
+            "SPDXID": "SPDXRef-EpollShim_jll-2702e6a9-849d-5ed8-8c21-79e8b8f9ee43",
+            "versionInfo": "0.0.20230411+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/EpollShim_jll.jl.git@v0.0.20230411+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "efa9718c40b48b4bc8d0fd0815422d77e4ee9975"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/EpollShim_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Wayland_jll",
+            "SPDXID": "SPDXRef-Wayland_jll-a2964d1f-97da-50d4-b82a-358c7fce9d89",
+            "versionInfo": "1.21.0+1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Wayland_jll.jl.git@v1.21.0+1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "d2e96db3e86356a06fd323a9e53b452e0bbfe1a6"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Wayland_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Wayland_protocols",
+            "SPDXID": "SPDXRef-f42f9d226c70f0bc88e5f897d914d9de1ac2ce03",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Wayland_protocols_jll.jl/releases/download/Wayland_protocols-v1.25.0+0/Wayland_protocols.v1.25.0.any.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "d1a84e0016d12f933a2ef390a0fa7db442df631c6c42a433c2b1c207f89f92f5"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "Wayland_protocols_jll",
+            "SPDXID": "SPDXRef-Wayland_protocols_jll-2381bf8a-dfd0-557d-9999-79630e7b1b91",
+            "versionInfo": "1.25.0+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Wayland_protocols_jll.jl.git@v1.25.0+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "2f8d369369250f88bcf8c20a10fdbc8e78fbeabb"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Wayland_protocols_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "xkbcommon_jll",
+            "SPDXID": "SPDXRef-xkbcommon_jll-d8fb68d0-12a3-5cfd-a85a-d49703b185fd",
+            "versionInfo": "1.4.1+1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/xkbcommon_jll.jl.git@v1.4.1+1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "8585defbc097eef494af6c4da52f7703caa92b68"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/xkbcommon_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Vulkan_Loader",
+            "SPDXID": "SPDXRef-4b3b2d79556cc3aef6e3d8a234649cc85b91bb87",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Vulkan_Loader_jll.jl/releases/download/Vulkan_Loader-v1.3.243+0/Vulkan_Loader.v1.3.243.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "a530e19d093da75429f17f2776ebcc0abba0684204bd09ee9892d98c987089de"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "Vulkan_Loader_jll",
+            "SPDXID": "SPDXRef-Vulkan_Loader_jll-a44049a8-05dd-5a78-86c9-5fde0876e88c",
+            "versionInfo": "1.3.243+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Vulkan_Loader_jll.jl.git@v1.3.243+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "9111b7c40f6bd6512c1746736163abcd6945130a"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Vulkan_Loader_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Xorg_libICE_jll",
+            "SPDXID": "SPDXRef-Xorg_libICE_jll-f67eecfb-183a-506d-b269-f58e52b52d7c",
+            "versionInfo": "1.0.10+1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_libICE_jll.jl.git@v1.0.10+1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "acc38720b068b6a008b54077ea7289cd6698b9ee"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_libICE_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Xorg_libSM_jll",
+            "SPDXID": "SPDXRef-Xorg_libSM_jll-c834827a-8449-5923-a945-d239c165b7dd",
+            "versionInfo": "1.2.3+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_libSM_jll.jl.git@v1.2.3+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "469afe1d3bec1eadb5e7653499bd6bd2ff8ae725"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_libSM_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "gperf",
+            "SPDXID": "SPDXRef-34b9a5702fe42ddb003e7885ea3ab18b3c108b58",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/gperf_jll.jl/releases/download/gperf-v3.1.1+0/gperf.v3.1.1.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "dd035c166b3d6e756ff81d72cbaa433a6f6881f60768163b38f9c80bdde833db"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "gperf_jll",
+            "SPDXID": "SPDXRef-gperf_jll-1a1c6b14-54f6-533d-8383-74cd7377aa70",
+            "versionInfo": "3.1.1+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/gperf_jll.jl.git@v3.1.1+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "f7aebf95d297a20f71c33a238aee087ad2a5a01a"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/gperf_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "eudev_jll",
+            "SPDXID": "SPDXRef-eudev_jll-35ca27e7-8b34-5b7f-bca9-bdc33f59eb06",
+            "versionInfo": "3.2.9+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/eudev_jll.jl.git@v3.2.9+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "86340941c2a0307c11c246dd267b505d78682e1d"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/eudev_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "libevdev_jll",
+            "SPDXID": "SPDXRef-libevdev_jll-2db6ffa8-e38f-5e21-84af-90c45d0032cc",
+            "versionInfo": "1.11.0+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/libevdev_jll.jl.git@v1.11.0+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "80a2464978c490d838be4b61669e948d43987487"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/libevdev_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "mtdev_jll",
+            "SPDXID": "SPDXRef-mtdev_jll-009596ad-96f7-51b1-9f1b-5ce2d5e8a71e",
+            "versionInfo": "1.1.6+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/mtdev_jll.jl.git@v1.1.6+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "f7e6a0a04b38fc84a146cd57a74722d249538487"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/mtdev_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "libinput_jll",
+            "SPDXID": "SPDXRef-libinput_jll-36db933b-70db-51c0-b978-0f229ee0e533",
+            "versionInfo": "1.18.0+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/libinput_jll.jl.git@v1.18.0+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "b764ce9cbd3cfa4a9b0eec82515c1bb4d834df38"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/libinput_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Xorg_xcb_util_wm_jll",
+            "SPDXID": "SPDXRef-Xorg_xcb_util_wm_jll-c22f9ab0-d5fe-5066-847c-f4bb1cd4e361",
+            "versionInfo": "0.4.1+1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_wm_jll.jl.git@v0.4.1+1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "2205b9c9808908bb25643cba13baee7516f35f94"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_wm_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Xorg_xcb_util_renderutil_jll",
+            "SPDXID": "SPDXRef-Xorg_xcb_util_renderutil_jll-0d47668e-0667-5a69-a72c-f761630bfb7e",
+            "versionInfo": "0.3.9+1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_renderutil_jll.jl.git@v0.3.9+1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "4ede5a3e816dd956841262e9382b89f986cb6cac"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_renderutil_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Xorg_xcb_util_keysyms_jll",
+            "SPDXID": "SPDXRef-Xorg_xcb_util_keysyms_jll-975044d2-76e6-5fbe-bf08-97ce7c6574c7",
+            "versionInfo": "0.4.0+1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_keysyms_jll.jl.git@v0.4.0+1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "f9318a072527fec2a7fa9c5351fd0bb469dea62b"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_keysyms_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Xorg_xcb_util_cursor_jll",
+            "SPDXID": "SPDXRef-Xorg_xcb_util_cursor_jll-e920d4aa-a673-5f3a-b3d7-f755a4d47c43",
+            "versionInfo": "0.1.4+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_cursor_jll.jl.git@v0.1.4+0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "89dd0d22375d8c89d9063dfcb748272d3833487f"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Xorg_xcb_util_cursor_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Qt6Base",
+            "SPDXID": "SPDXRef-dc1fe71ef939802ae7490350407bea0f47e5be5f",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Qt6Base_jll.jl/releases/download/Qt6Base-v6.5.3+1/Qt6Base.v6.5.3.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "777abad26608678aa03b45bdf9883d1c4ba8f4de977e67e76c365705708a8715"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "Qt6Base_jll",
+            "SPDXID": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56",
+            "versionInfo": "6.5.3+1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Qt6Base_jll.jl.git@v6.5.3+1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "94fe454c774b8c8a0c46bf65b4dfa745427c19f3"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Qt6Base_jll.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "GR",
+            "SPDXID": "SPDXRef-f1af74bc0a21f699d4974bdceac10d4638e61e74",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/GR_jll.jl/releases/download/GR-v0.72.10+0/GR.v0.72.10.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "7347a002a974dc0e54f816c9fc6371e9a058e2e4796df3dd3649fb77a1aa992c"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "GR_jll",
             "SPDXID": "SPDXRef-GR_jll-d2c73de3-f751-5644-a686-071e5b155ba9",
-            "versionInfo": "0.72.4+0",
+            "versionInfo": "0.72.10+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/GR_jll.jl.git@v0.72.4+0",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/GR_jll.jl.git@v0.72.10+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "4cbac21043aa99456ad20fb07e88da1bddfc029f"
+                "packageVerificationCodeValue": "59b0d797d782f217d93cb58fbba91ddf8c358207"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/GR_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -2258,18 +3658,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "GR",
             "SPDXID": "SPDXRef-GR-28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71",
-            "versionInfo": "0.72.4",
+            "versionInfo": "0.72.10",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/jheinen/GR.jl.git@v0.72.4",
+            "downloadLocation": "git+https://github.com/jheinen/GR.jl.git@v0.72.10",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "5eb7420e8f6d539a19964f50d4c3576de9db39d1"
+                "packageVerificationCodeValue": "79d6fb037c2aff4802a06bb5abda015c76b3621b"
             },
             "homepage": "https://github.com/jheinen/GR.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -2279,6 +3680,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -2300,6 +3702,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -2321,18 +3724,43 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "fzf",
+            "SPDXID": "SPDXRef-1b43124b7d46af53ca1fafbd6ab54c8a8ca51960",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/fzf_jll.jl/releases/download/fzf-v0.43.0+0/fzf.v0.43.0.aarch64-apple-darwin.tar.gz",
+            "filesAnalyzed": true,
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "411a2621008fa35e21ed96a470bbcd555eb452af80f63c752bccbce3a389acff"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: aarch64\nos: macos\n",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
         },
         {
             "name": "fzf_jll",
             "SPDXID": "SPDXRef-fzf_jll-214eeab7-80f7-51ab-84ad-2988db7cef09",
-            "versionInfo": "0.29.0+0",
+            "versionInfo": "0.43.0+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/fzf_jll.jl.git@v0.29.0+0",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/fzf_jll.jl.git@v0.43.0+0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "3996c85f42bcb9debc9b1739270e0252773d5c25"
+                "packageVerificationCodeValue": "4c12fbf5a456e97129bedcd3434157dfd5a55bb8"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/fzf_jll.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -2342,18 +3770,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "JLFzf",
             "SPDXID": "SPDXRef-JLFzf-1019f520-868f-41f5-a6de-eb00f4b6a39c",
-            "versionInfo": "0.1.5",
+            "versionInfo": "0.1.7",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/Moelf/JLFzf.jl.git@v0.1.5",
+            "downloadLocation": "git+https://github.com/Moelf/JLFzf.jl.git@v0.1.7",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "f4adb1350cb6a461be2d21365bde85a9c03ff1c3"
+                "packageVerificationCodeValue": "aaf4cbe8295ac160900ef69169605fe2f3b96459"
             },
             "homepage": "https://github.com/Moelf/JLFzf.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -2363,6 +3792,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -2384,20 +3814,21 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
-            "name": "RecipesBase",
-            "SPDXID": "SPDXRef-RecipesBase-3cdcf5f2-1ef4-517c-9805-6587b60abb01",
-            "versionInfo": "1.3.4",
+            "name": "Unitful",
+            "SPDXID": "SPDXRef-Unitful-1986cc42-f94f-5a68-af5c-568840ba703d",
+            "versionInfo": "1.19.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaPlots/Plots.jl.git@v1.3.4",
+            "downloadLocation": "git+https://github.com/PainterQubits/Unitful.jl.git@v1.19.0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "b9c9f36eaadb6574fa27d3c5378f86bd3e3ccebb"
+                "packageVerificationCodeValue": "1acec0512d8514218c8e2080bc4f067d634683fd"
             },
-            "homepage": "https://github.com/JuliaPlots/Plots.jl.git",
+            "homepage": "https://github.com/PainterQubits/Unitful.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
             "licenseConcluded": "NOASSERTION",
             "licenseInfoFromFiles": [
@@ -2405,20 +3836,21 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
-            "name": "ColorTypes",
-            "SPDXID": "SPDXRef-ColorTypes-3da002f7-5984-5a60-b8a6-cbb66c0b333f",
-            "versionInfo": "0.11.4",
+            "name": "Formatting",
+            "SPDXID": "SPDXRef-Formatting-59287772-0a20-5a39-b81b-1366585eb4c0",
+            "versionInfo": "0.4.2",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaGraphics/ColorTypes.jl.git@v0.11.4",
+            "downloadLocation": "git+https://github.com/JuliaIO/Formatting.jl.git@v0.4.2",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "545368ea0b9397fd52d290c47e112e7b0271822b"
+                "packageVerificationCodeValue": "1fb5a63d486fa5ef74c58d626adae8a143a3a7e2"
             },
-            "homepage": "https://github.com/JuliaGraphics/ColorTypes.jl.git",
+            "homepage": "https://github.com/JuliaIO/Formatting.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
             "licenseConcluded": "NOASSERTION",
             "licenseInfoFromFiles": [
@@ -2426,405 +3858,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "TensorCore",
-            "SPDXID": "SPDXRef-TensorCore-62fd8b95-f654-4bbd-a8a5-9c27f68ccd50",
-            "versionInfo": "0.1.1",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaMath/TensorCore.jl.git@v0.1.1",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "a8a57478c29a4832d76e8e25ec3e886b1cc3bed7"
-            },
-            "homepage": "https://github.com/JuliaMath/TensorCore.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "IrrationalConstants",
-            "SPDXID": "SPDXRef-IrrationalConstants-92d709cd-6900-40b7-9082-c6be49f344b6",
-            "versionInfo": "0.2.2",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaMath/IrrationalConstants.jl.git@v0.2.2",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "4d41f751d46adcab1135ded3126803115fbb5a6d"
-            },
-            "homepage": "https://github.com/JuliaMath/IrrationalConstants.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "ChainRulesCore",
-            "SPDXID": "SPDXRef-ChainRulesCore-d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4",
-            "versionInfo": "1.16.0",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaDiff/ChainRulesCore.jl.git@v1.16.0",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "ef7d7d646c6af366a87e329eab414782c30fb35d"
-            },
-            "homepage": "https://github.com/JuliaDiff/ChainRulesCore.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "ChangesOfVariables",
-            "SPDXID": "SPDXRef-ChangesOfVariables-9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0",
-            "versionInfo": "0.1.7",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaMath/ChangesOfVariables.jl.git@v0.1.7",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "28e9026fa9f1465345831ede4943d69444ed5d2b"
-            },
-            "homepage": "https://github.com/JuliaMath/ChangesOfVariables.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "DocStringExtensions",
-            "SPDXID": "SPDXRef-DocStringExtensions-ffbed154-4ef7-542d-bbb7-c09d3a79fcae",
-            "versionInfo": "0.9.3",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaDocs/DocStringExtensions.jl.git@v0.9.3",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "fc05fe2a1d4cdfb921a5a461ff15488b1103d985"
-            },
-            "homepage": "https://github.com/JuliaDocs/DocStringExtensions.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "InverseFunctions",
-            "SPDXID": "SPDXRef-InverseFunctions-3587e190-3f89-42d0-90ee-14403ec27112",
-            "versionInfo": "0.1.9",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaMath/InverseFunctions.jl.git@v0.1.9",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "2a14910cafd04e4c3c6095c03fa44128a428cb7d"
-            },
-            "homepage": "https://github.com/JuliaMath/InverseFunctions.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "LogExpFunctions",
-            "SPDXID": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688",
-            "versionInfo": "0.3.23",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaStats/LogExpFunctions.jl.git@v0.3.23",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "d83d16ff2b54f626113380a21ce4b25a1f2f46f0"
-            },
-            "homepage": "https://github.com/JuliaStats/LogExpFunctions.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "OpenSpecFun_jll",
-            "SPDXID": "SPDXRef-OpenSpecFun_jll-efe28fd5-8261-553b-a9e1-b2916fc3738e",
-            "versionInfo": "0.5.5+0",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/OpenSpecFun_jll.jl.git@v0.5.5+0",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "28fa753006006312d1be8b9dd7f553a35f7fe7aa"
-            },
-            "homepage": "https://github.com/JuliaBinaryWrappers/OpenSpecFun_jll.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "SpecialFunctions",
-            "SPDXID": "SPDXRef-SpecialFunctions-276daf66-3868-5448-9aa4-cd146d93841b",
-            "versionInfo": "2.2.0",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaMath/SpecialFunctions.jl.git@v2.2.0",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "1436746dc78f17f13962ade29e2248b646930586"
-            },
-            "homepage": "https://github.com/JuliaMath/SpecialFunctions.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "ColorVectorSpace",
-            "SPDXID": "SPDXRef-ColorVectorSpace-c3611d14-8923-5661-9e6a-0046d554d3a4",
-            "versionInfo": "0.9.10",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaGraphics/ColorVectorSpace.jl.git@v0.9.10",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "1205008c9dd8b42f16bcca9dc404bdd83c7ca996"
-            },
-            "homepage": "https://github.com/JuliaGraphics/ColorVectorSpace.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Colors",
-            "SPDXID": "SPDXRef-Colors-5ae59095-9a9b-59fe-a467-6f913c188581",
-            "versionInfo": "0.12.10",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaGraphics/Colors.jl.git@v0.12.10",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "af182d5bdf9dcb64c53d943ec1b6c8a53fa8d1a7"
-            },
-            "homepage": "https://github.com/JuliaGraphics/Colors.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "ColorSchemes",
-            "SPDXID": "SPDXRef-ColorSchemes-35d6a980-a343-548e-a6ea-1d62b119f2f4",
-            "versionInfo": "3.21.0",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaGraphics/ColorSchemes.jl.git@v3.21.0",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "6c7be2226756f582f7edc6250f870fd3e9784e5c"
-            },
-            "homepage": "https://github.com/JuliaGraphics/ColorSchemes.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "PlotUtils",
-            "SPDXID": "SPDXRef-PlotUtils-995b91a9-d308-5afd-9ec6-746e21dbc043",
-            "versionInfo": "1.3.5",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaPlots/PlotUtils.jl.git@v1.3.5",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "f312bdee78387e6adeb32b485198f4d70591ea29"
-            },
-            "homepage": "https://github.com/JuliaPlots/PlotUtils.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "NaNMath",
-            "SPDXID": "SPDXRef-NaNMath-77ba4419-2d1f-58cd-9bb1-8ffee604a2e3",
-            "versionInfo": "1.0.2",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaMath/NaNMath.jl.git@v1.0.2",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "4d618cf7d35f6ea96bc89671a2ceeef0aa298ada"
-            },
-            "homepage": "https://github.com/JuliaMath/NaNMath.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "RecipesPipeline",
-            "SPDXID": "SPDXRef-RecipesPipeline-01d81517-befc-4cb6-b9ec-a95719d0359c",
-            "versionInfo": "0.6.12",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaPlots/Plots.jl.git@v0.6.12",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "05d359192c2402777bd995f494bd362f7c990667"
-            },
-            "homepage": "https://github.com/JuliaPlots/Plots.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "StatsAPI",
-            "SPDXID": "SPDXRef-StatsAPI-82ae8749-77ed-4fe6-ae5f-f523153014b0",
-            "versionInfo": "1.6.0",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaStats/StatsAPI.jl.git@v1.6.0",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "d24c1ae4e04479d508011452a36a5ab5b5eb895c"
-            },
-            "homepage": "https://github.com/JuliaStats/StatsAPI.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "StatsBase",
-            "SPDXID": "SPDXRef-StatsBase-2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91",
-            "versionInfo": "0.33.21",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaStats/StatsBase.jl.git@v0.33.21",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "22f652e7f4d2204c84b0b6f4d179a01a24d250b1"
-            },
-            "homepage": "https://github.com/JuliaStats/StatsBase.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "Scratch",
-            "SPDXID": "SPDXRef-Scratch-6c6a2e73-6563-6170-7368-637461726353",
-            "versionInfo": "1.2.0",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaPackaging/Scratch.jl.git@v1.2.0",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "0848deb154f38c7e53f2f9e20cd58ae609d014cf"
-            },
-            "homepage": "https://github.com/JuliaPackaging/Scratch.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "RelocatableFolders",
-            "SPDXID": "SPDXRef-RelocatableFolders-05181044-ff0b-4ac5-8273-598c1e38db00",
-            "versionInfo": "1.0.0",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaPackaging/RelocatableFolders.jl.git@v1.0.0",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "ed80f771eb909f7917d444e272d43de5139a6ff2"
-            },
-            "homepage": "https://github.com/JuliaPackaging/RelocatableFolders.jl.git",
-            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "NOASSERTION"
-            ],
-            "licenseDeclared": "NOASSERTION",
-            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -2846,18 +3880,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "MacroTools",
             "SPDXID": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
-            "versionInfo": "0.5.10",
+            "versionInfo": "0.5.12",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/FluxML/MacroTools.jl.git@v0.5.10",
+            "downloadLocation": "git+https://github.com/FluxML/MacroTools.jl.git@v0.5.12",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "86d562f205070e3deaa8fc302310f5042efb3bcb"
+                "packageVerificationCodeValue": "b80026a1df8ea92535bdc16b98e6fcd75024db50"
             },
             "homepage": "https://github.com/FluxML/MacroTools.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -2867,18 +3902,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "Latexify",
             "SPDXID": "SPDXRef-Latexify-23fbe1c1-3f47-55db-b15f-69d7ec21a316",
-            "versionInfo": "0.16.0",
+            "versionInfo": "0.16.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/korsbo/Latexify.jl.git@v0.16.0",
+            "downloadLocation": "git+https://github.com/korsbo/Latexify.jl.git@v0.16.1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "073baf56f9c6b32debdd53e6852aaef613bdc5a9"
+                "packageVerificationCodeValue": "75c2615cc13cd52cb405bc00ceec1afb826dea61"
             },
             "homepage": "https://github.com/korsbo/Latexify.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -2888,6 +3924,381 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "UnitfulLatexify",
+            "SPDXID": "SPDXRef-UnitfulLatexify-45397f5d-5981-4c77-b2b3-fc36d6e9b728",
+            "versionInfo": "1.6.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/gustaphe/UnitfulLatexify.jl.git@v1.6.3",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "a3645c0508749d8cfdc3b99651fe89e233507366"
+            },
+            "homepage": "https://github.com/gustaphe/UnitfulLatexify.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "RecipesBase",
+            "SPDXID": "SPDXRef-RecipesBase-3cdcf5f2-1ef4-517c-9805-6587b60abb01",
+            "versionInfo": "1.3.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPlots/Plots.jl.git@v1.3.4#RecipesBase",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "b9c9f36eaadb6574fa27d3c5378f86bd3e3ccebb"
+            },
+            "homepage": "https://github.com/JuliaPlots/Plots.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ColorTypes",
+            "SPDXID": "SPDXRef-ColorTypes-3da002f7-5984-5a60-b8a6-cbb66c0b333f",
+            "versionInfo": "0.11.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaGraphics/ColorTypes.jl.git@v0.11.4",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "545368ea0b9397fd52d290c47e112e7b0271822b"
+            },
+            "homepage": "https://github.com/JuliaGraphics/ColorTypes.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "TensorCore",
+            "SPDXID": "SPDXRef-TensorCore-62fd8b95-f654-4bbd-a8a5-9c27f68ccd50",
+            "versionInfo": "0.1.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaMath/TensorCore.jl.git@v0.1.1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "a8a57478c29a4832d76e8e25ec3e886b1cc3bed7"
+            },
+            "homepage": "https://github.com/JuliaMath/TensorCore.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ColorVectorSpace",
+            "SPDXID": "SPDXRef-ColorVectorSpace-c3611d14-8923-5661-9e6a-0046d554d3a4",
+            "versionInfo": "0.10.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaGraphics/ColorVectorSpace.jl.git@v0.10.0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "f1bb521505dbc579fac33dba5d2e7b7658ee4fbf"
+            },
+            "homepage": "https://github.com/JuliaGraphics/ColorVectorSpace.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Colors",
+            "SPDXID": "SPDXRef-Colors-5ae59095-9a9b-59fe-a467-6f913c188581",
+            "versionInfo": "0.12.10",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaGraphics/Colors.jl.git@v0.12.10",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "af182d5bdf9dcb64c53d943ec1b6c8a53fa8d1a7"
+            },
+            "homepage": "https://github.com/JuliaGraphics/Colors.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ColorSchemes",
+            "SPDXID": "SPDXRef-ColorSchemes-35d6a980-a343-548e-a6ea-1d62b119f2f4",
+            "versionInfo": "3.24.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaGraphics/ColorSchemes.jl.git@v3.24.0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "7fbcea9216819f26e334350ae9ec6f507fce565a"
+            },
+            "homepage": "https://github.com/JuliaGraphics/ColorSchemes.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "PlotUtils",
+            "SPDXID": "SPDXRef-PlotUtils-995b91a9-d308-5afd-9ec6-746e21dbc043",
+            "versionInfo": "1.4.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPlots/PlotUtils.jl.git@v1.4.0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "2d66c8a7f428cdec33a86dfbbcee0945e20e12b0"
+            },
+            "homepage": "https://github.com/JuliaPlots/PlotUtils.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "NaNMath",
+            "SPDXID": "SPDXRef-NaNMath-77ba4419-2d1f-58cd-9bb1-8ffee604a2e3",
+            "versionInfo": "1.0.2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaMath/NaNMath.jl.git@v1.0.2",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "4d618cf7d35f6ea96bc89671a2ceeef0aa298ada"
+            },
+            "homepage": "https://github.com/JuliaMath/NaNMath.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "RecipesPipeline",
+            "SPDXID": "SPDXRef-RecipesPipeline-01d81517-befc-4cb6-b9ec-a95719d0359c",
+            "versionInfo": "0.6.12",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPlots/Plots.jl.git@v0.6.12#RecipesPipeline",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "05d359192c2402777bd995f494bd362f7c990667"
+            },
+            "homepage": "https://github.com/JuliaPlots/Plots.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "IrrationalConstants",
+            "SPDXID": "SPDXRef-IrrationalConstants-92d709cd-6900-40b7-9082-c6be49f344b6",
+            "versionInfo": "0.2.2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaMath/IrrationalConstants.jl.git@v0.2.2",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "4d41f751d46adcab1135ded3126803115fbb5a6d"
+            },
+            "homepage": "https://github.com/JuliaMath/IrrationalConstants.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "DocStringExtensions",
+            "SPDXID": "SPDXRef-DocStringExtensions-ffbed154-4ef7-542d-bbb7-c09d3a79fcae",
+            "versionInfo": "0.9.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaDocs/DocStringExtensions.jl.git@v0.9.3",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "fc05fe2a1d4cdfb921a5a461ff15488b1103d985"
+            },
+            "homepage": "https://github.com/JuliaDocs/DocStringExtensions.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "LogExpFunctions",
+            "SPDXID": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688",
+            "versionInfo": "0.3.26",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaStats/LogExpFunctions.jl.git@v0.3.26",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "e70072e2db34e6e74e60094a140eeec441e48b58"
+            },
+            "homepage": "https://github.com/JuliaStats/LogExpFunctions.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "StatsAPI",
+            "SPDXID": "SPDXRef-StatsAPI-82ae8749-77ed-4fe6-ae5f-f523153014b0",
+            "versionInfo": "1.7.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaStats/StatsAPI.jl.git@v1.7.0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "b4f0fcd63192c9eba1e5937c3b8bcd92495bdc8e"
+            },
+            "homepage": "https://github.com/JuliaStats/StatsAPI.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "StatsBase",
+            "SPDXID": "SPDXRef-StatsBase-2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91",
+            "versionInfo": "0.34.2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaStats/StatsBase.jl.git@v0.34.2",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "be43ec964f7730ba5c3f5f8297e7e93aaf8b5305"
+            },
+            "homepage": "https://github.com/JuliaStats/StatsBase.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Scratch",
+            "SPDXID": "SPDXRef-Scratch-6c6a2e73-6563-6170-7368-637461726353",
+            "versionInfo": "1.2.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Scratch.jl.git@v1.2.1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "871d28464add07fe83fa4dc485efc5ba458b764b"
+            },
+            "homepage": "https://github.com/JuliaPackaging/Scratch.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "RelocatableFolders",
+            "SPDXID": "SPDXRef-RelocatableFolders-05181044-ff0b-4ac5-8273-598c1e38db00",
+            "versionInfo": "1.0.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/RelocatableFolders.jl.git@v1.0.1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "a08d1a83b16535d9badb43ccafede64d2014bc24"
+            },
+            "homepage": "https://github.com/JuliaPackaging/RelocatableFolders.jl.git",
+            "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "NOASSERTION"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -2909,6 +4320,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -2930,6 +4342,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -2951,6 +4364,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -2972,6 +4386,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
@@ -2993,18 +4408,19 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
             "name": "Plots",
             "SPDXID": "SPDXRef-Plots-91a5bcdd-55d7-5caf-9e0b-520d859cae80",
-            "versionInfo": "1.38.11",
+            "versionInfo": "1.39.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaPlots/Plots.jl.git@v1.38.11",
+            "downloadLocation": "git+https://github.com/JuliaPlots/Plots.jl.git@v1.39.0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "c0cf7923e51b6db8cbc0f5dec9900826e47d2006"
+                "packageVerificationCodeValue": "f4cad66ac63049874e6faebfd95e82542e77be41"
             },
             "homepage": "https://github.com/JuliaPlots/Plots.jl.git",
             "sourceInfo": "Source Code Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git",
@@ -3014,6 +4430,7 @@
             ],
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         }
     ],
@@ -3184,6 +4601,11 @@
             "relatedSpdxElement": "SPDXRef-DataFrames-a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
         },
         {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DataFrames-a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+        },
+        {
             "spdxElementId": "SPDXRef-InvertedIndices-41ab1584-1d38-5bbf-9106-f11c6c58b48f",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-DataFrames-a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -3204,12 +4626,7 @@
             "relatedSpdxElement": "SPDXRef-DataFrames-a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
         },
         {
-            "spdxElementId": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-SnoopPrecompile-66db9d55-30c0-4569-8b51-7e840670fc0c"
-        },
-        {
-            "spdxElementId": "SPDXRef-SnoopPrecompile-66db9d55-30c0-4569-8b51-7e840670fc0c",
+            "spdxElementId": "SPDXRef-DataStructures-864edb3b-99cc-5e75-8d2d-829cb0a9cfe8",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-DataFrames-a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
         },
@@ -3229,17 +4646,22 @@
             "relatedSpdxElement": "SPDXRef-DataFrames-a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
         },
         {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StringManipulation-892a3eda-7b42-436c-8928-eab12a02cf0e"
+        },
+        {
             "spdxElementId": "SPDXRef-StringManipulation-892a3eda-7b42-436c-8928-eab12a02cf0e",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
         },
         {
-            "spdxElementId": "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c",
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
         },
         {
-            "spdxElementId": "SPDXRef-Formatting-59287772-0a20-5a39-b81b-1366585eb4c0",
+            "spdxElementId": "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
         },
@@ -3304,6 +4726,11 @@
             "relatedSpdxElement": "SPDXRef-HTTP-cd3eb016-35fb-5094-929b-558a96fad6f3"
         },
         {
+            "spdxElementId": "SPDXRef-ExceptionUnwrapping-460bff9d-24e4-43bc-9d9f-a8973cb893f4",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-HTTP-cd3eb016-35fb-5094-929b-558a96fad6f3"
+        },
+        {
             "spdxElementId": "SPDXRef-MbedTLS-739be429-bea8-5141-9913-cc70e7f3736d",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-HTTP-cd3eb016-35fb-5094-929b-558a96fad6f3"
@@ -3316,6 +4743,11 @@
         {
             "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OpenSSL_jll-458c3c95-2e84-50aa-8efc-19380b2a3a95"
+        },
+        {
+            "spdxElementId": "SPDXRef-779e94a792b089936ee92f4122727d8f76929cfb",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-OpenSSL_jll-458c3c95-2e84-50aa-8efc-19380b2a3a95"
         },
         {
@@ -3344,6 +4776,11 @@
             "relatedSpdxElement": "SPDXRef-GR-28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
         },
         {
+            "spdxElementId": "SPDXRef-DelimitedFiles-8bb1440f-4735-579b-a4ab-409b98df4dab",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-GR-28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
+        },
+        {
             "spdxElementId": "SPDXRef-JSON-682c06a0-de6a-54ab-a142-c8b1cf79cde6",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-GR-28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
@@ -3361,6 +4798,11 @@
         {
             "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Bzip2_jll-6e34b625-4abd-537c-b88f-471c36dfa7a0"
+        },
+        {
+            "spdxElementId": "SPDXRef-2a86ef020f132332b2f4be2fb40912cc7df5da29",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-Bzip2_jll-6e34b625-4abd-537c-b88f-471c36dfa7a0"
         },
         {
@@ -3389,6 +4831,11 @@
             "relatedSpdxElement": "SPDXRef-FreeType2_jll-d7e528f0-a631-5988-bf34-fe36492bcfd7"
         },
         {
+            "spdxElementId": "SPDXRef-c65e07e3da4f1bf519bc432389dbbd61df320457",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-FreeType2_jll-d7e528f0-a631-5988-bf34-fe36492bcfd7"
+        },
+        {
             "spdxElementId": "SPDXRef-FreeType2_jll-d7e528f0-a631-5988-bf34-fe36492bcfd7",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-Fontconfig_jll-a3f928ae-7b40-5064-980b-68af3947d34b"
@@ -3399,8 +4846,18 @@
             "relatedSpdxElement": "SPDXRef-Expat_jll-2e619515-83b5-522b-bb60-26c02a35a201"
         },
         {
+            "spdxElementId": "SPDXRef-4ec62d729213a748d2300dd0832ebe8ed2292093",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Expat_jll-2e619515-83b5-522b-bb60-26c02a35a201"
+        },
+        {
             "spdxElementId": "SPDXRef-Expat_jll-2e619515-83b5-522b-bb60-26c02a35a201",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Fontconfig_jll-a3f928ae-7b40-5064-980b-68af3947d34b"
+        },
+        {
+            "spdxElementId": "SPDXRef-e6b9fb44029423f5cd69e0cbbff25abcc4b32a8f",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-Fontconfig_jll-a3f928ae-7b40-5064-980b-68af3947d34b"
         },
         {
@@ -3414,6 +4871,26 @@
             "relatedSpdxElement": "SPDXRef-Pixman_jll-30392449-352a-5448-841d-b1acce4e97dc"
         },
         {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LLVMOpenMP_jll-1d63c593-3942-5779-bab2-d838dc0a180e"
+        },
+        {
+            "spdxElementId": "SPDXRef-10b2b258c07d7a76b2e3331f1ed70d8a8eb6d71c",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LLVMOpenMP_jll-1d63c593-3942-5779-bab2-d838dc0a180e"
+        },
+        {
+            "spdxElementId": "SPDXRef-LLVMOpenMP_jll-1d63c593-3942-5779-bab2-d838dc0a180e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Pixman_jll-30392449-352a-5448-841d-b1acce4e97dc"
+        },
+        {
+            "spdxElementId": "SPDXRef-9a76a401f82e0e3cafce618fb8d2d5c307ab2836",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Pixman_jll-30392449-352a-5448-841d-b1acce4e97dc"
+        },
+        {
             "spdxElementId": "SPDXRef-Pixman_jll-30392449-352a-5448-841d-b1acce4e97dc",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-GR_jll-d2c73de3-f751-5644-a686-071e5b155ba9"
@@ -3421,6 +4898,11 @@
         {
             "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LAME_jll-c1c5ebd0-6772-5130-a774-d5fcae4a789d"
+        },
+        {
+            "spdxElementId": "SPDXRef-413111420faa4e2aeaa383c075eaa213402d939c",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-LAME_jll-c1c5ebd0-6772-5130-a774-d5fcae4a789d"
         },
         {
@@ -3434,6 +4916,11 @@
             "relatedSpdxElement": "SPDXRef-Opus_jll-91d4177d-7536-5919-b921-800302f37372"
         },
         {
+            "spdxElementId": "SPDXRef-4609432e7098d8434a7a4c7876dd5b9e09b2a5e7",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Opus_jll-91d4177d-7536-5919-b921-800302f37372"
+        },
+        {
             "spdxElementId": "SPDXRef-Opus_jll-91d4177d-7536-5919-b921-800302f37372",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-FFMPEG_jll-b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
@@ -3441,6 +4928,11 @@
         {
             "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-FriBidi_jll-559328eb-81f9-559d-9380-de523a88c83c"
+        },
+        {
+            "spdxElementId": "SPDXRef-df3881e810714d6a09467fe85a6fde79385fe702",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-FriBidi_jll-559328eb-81f9-559d-9380-de523a88c83c"
         },
         {
@@ -3454,6 +4946,11 @@
             "relatedSpdxElement": "SPDXRef-x264_jll-1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
         },
         {
+            "spdxElementId": "SPDXRef-0db9c3f6cf936a0da49e2ba954ba3e10bed6ad72",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-x264_jll-1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
+        },
+        {
             "spdxElementId": "SPDXRef-x264_jll-1270edf5-f2f9-52d2-97e9-ab00b5d0237a",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-FFMPEG_jll-b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
@@ -3461,6 +4958,11 @@
         {
             "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-libaom_jll-a4ae2306-e953-59d6-aa16-d00cac43593b"
+        },
+        {
+            "spdxElementId": "SPDXRef-c325a23bc1f6521474cef5f634f18c8ab311bb02",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-libaom_jll-a4ae2306-e953-59d6-aa16-d00cac43593b"
         },
         {
@@ -3484,8 +4986,18 @@
             "relatedSpdxElement": "SPDXRef-Ogg_jll-e7412a2a-1a6e-54c0-be00-318e2571c051"
         },
         {
+            "spdxElementId": "SPDXRef-ca2831bf6edc5088aec5b329ea98364951d6cad0",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Ogg_jll-e7412a2a-1a6e-54c0-be00-318e2571c051"
+        },
+        {
             "spdxElementId": "SPDXRef-Ogg_jll-e7412a2a-1a6e-54c0-be00-318e2571c051",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-libvorbis_jll-f27f6e37-5d2b-51aa-960f-b287f2bc3b7a"
+        },
+        {
+            "spdxElementId": "SPDXRef-3fe6bf926e57cc4be598151cd40832221de2e894",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-libvorbis_jll-f27f6e37-5d2b-51aa-960f-b287f2bc3b7a"
         },
         {
@@ -3501,6 +5013,11 @@
         {
             "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-x265_jll-dfaa095f-4041-5dcd-9319-2fabd8486b76"
+        },
+        {
+            "spdxElementId": "SPDXRef-1a7e22e66b523d9cb884cf85c3ec065b5fb3e5c3",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-x265_jll-dfaa095f-4041-5dcd-9319-2fabd8486b76"
         },
         {
@@ -3536,6 +5053,11 @@
         {
             "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Libffi_jll-e9f186c6-92d2-5b65-8a66-fee21dc1b490"
+        },
+        {
+            "spdxElementId": "SPDXRef-5b338c8fa90c05e6faea86e54d2996cca76cfbbe",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-Libffi_jll-e9f186c6-92d2-5b65-8a66-fee21dc1b490"
         },
         {
@@ -3579,8 +5101,18 @@
             "relatedSpdxElement": "SPDXRef-Libiconv_jll-94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
         },
         {
+            "spdxElementId": "SPDXRef-92b949e2f3a66439c69a8d334fc95810fbd9df9b",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Libiconv_jll-94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+        },
+        {
             "spdxElementId": "SPDXRef-Libiconv_jll-94ce4f54-9a6c-5748-9c1c-f9c7231a4531",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-XML2_jll-02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
+        },
+        {
+            "spdxElementId": "SPDXRef-d18fd9a0903c01ba831674a057a5ef7caf6aeec6",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-XML2_jll-02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
         },
         {
@@ -3591,6 +5123,11 @@
         {
             "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Libgpg_error_jll-7add5ba3-2f88-524e-9cd5-f83b8a55f7b8"
+        },
+        {
+            "spdxElementId": "SPDXRef-a110b2aa0a23e2f4498373c088a95ae6ba07b7f7",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-Libgpg_error_jll-7add5ba3-2f88-524e-9cd5-f83b8a55f7b8"
         },
         {
@@ -3609,6 +5146,11 @@
             "relatedSpdxElement": "SPDXRef-Libgcrypt_jll-d4300ac3-e22c-5743-9152-c294e39db1e4"
         },
         {
+            "spdxElementId": "SPDXRef-58860383d52098836448ae8a8d1247482bccda22",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Libgcrypt_jll-d4300ac3-e22c-5743-9152-c294e39db1e4"
+        },
+        {
             "spdxElementId": "SPDXRef-Libgcrypt_jll-d4300ac3-e22c-5743-9152-c294e39db1e4",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-XSLT_jll-aed1982a-8fda-507f-9586-7b0439959a61"
@@ -3616,6 +5158,11 @@
         {
             "spdxElementId": "SPDXRef-Libiconv_jll-94ce4f54-9a6c-5748-9c1c-f9c7231a4531",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-XSLT_jll-aed1982a-8fda-507f-9586-7b0439959a61"
+        },
+        {
+            "spdxElementId": "SPDXRef-40962d05f37e788d1c44ead73e045964323782bb",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-XSLT_jll-aed1982a-8fda-507f-9586-7b0439959a61"
         },
         {
@@ -3719,6 +5266,11 @@
             "relatedSpdxElement": "SPDXRef-Gettext_jll-78b55507-aeef-58d4-861c-77aaff3498b1"
         },
         {
+            "spdxElementId": "SPDXRef-9410bad2635eda2239b4a72ba4316c4aa8f5b76e",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Gettext_jll-78b55507-aeef-58d4-861c-77aaff3498b1"
+        },
+        {
             "spdxElementId": "SPDXRef-Gettext_jll-78b55507-aeef-58d4-861c-77aaff3498b1",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-Glib_jll-7746bdde-850d-59dc-9ae8-88ece973131d"
@@ -3741,6 +5293,11 @@
         {
             "spdxElementId": "SPDXRef-Libffi_jll-e9f186c6-92d2-5b65-8a66-fee21dc1b490",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Glib_jll-7746bdde-850d-59dc-9ae8-88ece973131d"
+        },
+        {
+            "spdxElementId": "SPDXRef-95f332911a8dd5ab82620ba58c217193bd0d515d",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-Glib_jll-7746bdde-850d-59dc-9ae8-88ece973131d"
         },
         {
@@ -3769,6 +5326,11 @@
             "relatedSpdxElement": "SPDXRef-libpng_jll-b53b4c65-9356-5827-b1ea-8c7a1a84506f"
         },
         {
+            "spdxElementId": "SPDXRef-e8b1e36798f9659162a3c55c9f0e772c685de558",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-libpng_jll-b53b4c65-9356-5827-b1ea-8c7a1a84506f"
+        },
+        {
             "spdxElementId": "SPDXRef-libpng_jll-b53b4c65-9356-5827-b1ea-8c7a1a84506f",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-Cairo_jll-83423d85-b0ee-5818-9007-b63ccbeb887a"
@@ -3779,8 +5341,18 @@
             "relatedSpdxElement": "SPDXRef-LZO_jll-dd4b983a-f0e5-5f8d-a1b7-129d4a5fb1ac"
         },
         {
+            "spdxElementId": "SPDXRef-b2108f561a8812e376eb80e71a24a3678a24d231",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LZO_jll-dd4b983a-f0e5-5f8d-a1b7-129d4a5fb1ac"
+        },
+        {
             "spdxElementId": "SPDXRef-LZO_jll-dd4b983a-f0e5-5f8d-a1b7-129d4a5fb1ac",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Cairo_jll-83423d85-b0ee-5818-9007-b63ccbeb887a"
+        },
+        {
+            "spdxElementId": "SPDXRef-ada2a202928dd4cb2fc4bd18c4efa9d5455ec742",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-Cairo_jll-83423d85-b0ee-5818-9007-b63ccbeb887a"
         },
         {
@@ -3809,8 +5381,18 @@
             "relatedSpdxElement": "SPDXRef-Graphite2_jll-3b182d85-2403-5c21-9c21-1e1f0cc25472"
         },
         {
+            "spdxElementId": "SPDXRef-3b3d0bcaf14a9b239a4f4dc20ef7b9e63030a47e",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Graphite2_jll-3b182d85-2403-5c21-9c21-1e1f0cc25472"
+        },
+        {
             "spdxElementId": "SPDXRef-Graphite2_jll-3b182d85-2403-5c21-9c21-1e1f0cc25472",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-HarfBuzz_jll-2e76f6c2-a576-52d4-95c1-20adfe4de566"
+        },
+        {
+            "spdxElementId": "SPDXRef-abf161ac3d4df76ae74bbf5432b7e061b3876236",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-HarfBuzz_jll-2e76f6c2-a576-52d4-95c1-20adfe4de566"
         },
         {
@@ -3824,6 +5406,11 @@
             "relatedSpdxElement": "SPDXRef-libass_jll-0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
         },
         {
+            "spdxElementId": "SPDXRef-4260cf51a368d8e305a5de3669e32539e1e6cc72",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-libass_jll-0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
+        },
+        {
             "spdxElementId": "SPDXRef-libass_jll-0ac62f75-1d6f-5e53-bd7c-93b484bb37c0",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-FFMPEG_jll-b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
@@ -3831,6 +5418,11 @@
         {
             "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-libfdk_aac_jll-f638f0a6-7fb0-5443-88ba-1cc74229b280"
+        },
+        {
+            "spdxElementId": "SPDXRef-fc7ba632b72ce7d852c1924aa2bbfe244a71c780",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-libfdk_aac_jll-f638f0a6-7fb0-5443-88ba-1cc74229b280"
         },
         {
@@ -3849,6 +5441,11 @@
             "relatedSpdxElement": "SPDXRef-FFMPEG_jll-b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
         },
         {
+            "spdxElementId": "SPDXRef-6095fcd268ea712c0f786f5ff1a45bf0eb7b005e",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-FFMPEG_jll-b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
+        },
+        {
             "spdxElementId": "SPDXRef-FFMPEG_jll-b22a6f82-2f65-5046-a5b2-351ab43fb4e5",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-GR_jll-d2c73de3-f751-5644-a686-071e5b155ba9"
@@ -3859,222 +5456,22 @@
             "relatedSpdxElement": "SPDXRef-JpegTurbo_jll-aacddb02-875f-59d6-b918-886e6ef4fbf8"
         },
         {
+            "spdxElementId": "SPDXRef-b80d54484d815d1ace4cb475d53da633579d7d92",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JpegTurbo_jll-aacddb02-875f-59d6-b918-886e6ef4fbf8"
+        },
+        {
             "spdxElementId": "SPDXRef-JpegTurbo_jll-aacddb02-875f-59d6-b918-886e6ef4fbf8",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-GR_jll-d2c73de3-f751-5644-a686-071e5b155ba9"
         },
         {
-            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Libglvnd_jll-7e76a0d4-f3c7-5321-8279-8d96eeed0f29"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_libXext_jll-1082639a-0dae-5f34-9b06-72781eeb8cb3",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Libglvnd_jll-7e76a0d4-f3c7-5321-8279-8d96eeed0f29"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_libX11_jll-4f6342f7-b3d2-589e-9d20-edeb45f2b2bc",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Libglvnd_jll-7e76a0d4-f3c7-5321-8279-8d96eeed0f29"
-        },
-        {
-            "spdxElementId": "SPDXRef-Libglvnd_jll-7e76a0d4-f3c7-5321-8279-8d96eeed0f29",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Qt5Base_jll-ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_libxcb_jll-c7cfdc94-dc32-55de-ac96-5a1b8d977c5b",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Qt5Base_jll-ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
-        },
-        {
-            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_image_jll-12413925-8142-5f55-bb0e-6d7ca50bb09b"
-        },
-        {
-            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_jll-2def613f-5ad1-5310-b15b-b15d46f528f5"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_libxcb_jll-c7cfdc94-dc32-55de-ac96-5a1b8d977c5b",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_jll-2def613f-5ad1-5310-b15b-b15d46f528f5"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_xcb_util_jll-2def613f-5ad1-5310-b15b-b15d46f528f5",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_image_jll-12413925-8142-5f55-bb0e-6d7ca50bb09b"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_xcb_util_image_jll-12413925-8142-5f55-bb0e-6d7ca50bb09b",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Qt5Base_jll-ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
-        },
-        {
-            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-xkbcommon_jll-d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_libxcb_jll-c7cfdc94-dc32-55de-ac96-5a1b8d977c5b",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-xkbcommon_jll-d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
-        },
-        {
-            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_xkeyboard_config_jll-33bec58e-1273-512f-9401-5d533626f822"
-        },
-        {
-            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_xkbcomp_jll-35661453-b289-5fab-8a00-3d9160c6a3a4"
-        },
-        {
-            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_libxkbfile_jll-cc61e674-0454-545c-8b26-ed2c68acab7a"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_libX11_jll-4f6342f7-b3d2-589e-9d20-edeb45f2b2bc",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_libxkbfile_jll-cc61e674-0454-545c-8b26-ed2c68acab7a"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_libxkbfile_jll-cc61e674-0454-545c-8b26-ed2c68acab7a",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_xkbcomp_jll-35661453-b289-5fab-8a00-3d9160c6a3a4"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_xkbcomp_jll-35661453-b289-5fab-8a00-3d9160c6a3a4",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_xkeyboard_config_jll-33bec58e-1273-512f-9401-5d533626f822"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_xkeyboard_config_jll-33bec58e-1273-512f-9401-5d533626f822",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-xkbcommon_jll-d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
-        },
-        {
-            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Wayland_jll-a2964d1f-97da-50d4-b82a-358c7fce9d89"
-        },
-        {
-            "spdxElementId": "SPDXRef-XML2_jll-02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Wayland_jll-a2964d1f-97da-50d4-b82a-358c7fce9d89"
-        },
-        {
-            "spdxElementId": "SPDXRef-Expat_jll-2e619515-83b5-522b-bb60-26c02a35a201",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Wayland_jll-a2964d1f-97da-50d4-b82a-358c7fce9d89"
-        },
-        {
-            "spdxElementId": "SPDXRef-Libffi_jll-e9f186c6-92d2-5b65-8a66-fee21dc1b490",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Wayland_jll-a2964d1f-97da-50d4-b82a-358c7fce9d89"
-        },
-        {
-            "spdxElementId": "SPDXRef-Wayland_jll-a2964d1f-97da-50d4-b82a-358c7fce9d89",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-xkbcommon_jll-d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
-        },
-        {
-            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Wayland_protocols_jll-2381bf8a-dfd0-557d-9999-79630e7b1b91"
-        },
-        {
-            "spdxElementId": "SPDXRef-Wayland_protocols_jll-2381bf8a-dfd0-557d-9999-79630e7b1b91",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-xkbcommon_jll-d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
-        },
-        {
-            "spdxElementId": "SPDXRef-xkbcommon_jll-d8fb68d0-12a3-5cfd-a85a-d49703b185fd",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Qt5Base_jll-ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
-        },
-        {
-            "spdxElementId": "SPDXRef-Fontconfig_jll-a3f928ae-7b40-5064-980b-68af3947d34b",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Qt5Base_jll-ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
-        },
-        {
-            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Qt5Base_jll-ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
-        },
-        {
-            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_wm_jll-c22f9ab0-d5fe-5066-847c-f4bb1cd4e361"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_xcb_util_jll-2def613f-5ad1-5310-b15b-b15d46f528f5",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_wm_jll-c22f9ab0-d5fe-5066-847c-f4bb1cd4e361"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_xcb_util_wm_jll-c22f9ab0-d5fe-5066-847c-f4bb1cd4e361",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Qt5Base_jll-ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
-        },
-        {
-            "spdxElementId": "SPDXRef-Glib_jll-7746bdde-850d-59dc-9ae8-88ece973131d",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Qt5Base_jll-ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
-        },
-        {
-            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_renderutil_jll-0d47668e-0667-5a69-a72c-f761630bfb7e"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_xcb_util_jll-2def613f-5ad1-5310-b15b-b15d46f528f5",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_renderutil_jll-0d47668e-0667-5a69-a72c-f761630bfb7e"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_xcb_util_renderutil_jll-0d47668e-0667-5a69-a72c-f761630bfb7e",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Qt5Base_jll-ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
-        },
-        {
-            "spdxElementId": "SPDXRef-OpenSSL_jll-458c3c95-2e84-50aa-8efc-19380b2a3a95",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Qt5Base_jll-ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_libXext_jll-1082639a-0dae-5f34-9b06-72781eeb8cb3",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Qt5Base_jll-ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
-        },
-        {
-            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_keysyms_jll-975044d2-76e6-5fbe-bf08-97ce7c6574c7"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_xcb_util_jll-2def613f-5ad1-5310-b15b-b15d46f528f5",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_keysyms_jll-975044d2-76e6-5fbe-bf08-97ce7c6574c7"
-        },
-        {
-            "spdxElementId": "SPDXRef-Xorg_xcb_util_keysyms_jll-975044d2-76e6-5fbe-bf08-97ce7c6574c7",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Qt5Base_jll-ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
-        },
-        {
-            "spdxElementId": "SPDXRef-Qt5Base_jll-ea2cea3b-5b76-57ae-a6ef-0a8af62496e1",
+            "spdxElementId": "SPDXRef-Cairo_jll-83423d85-b0ee-5818-9007-b63ccbeb887a",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-GR_jll-d2c73de3-f751-5644-a686-071e5b155ba9"
         },
         {
-            "spdxElementId": "SPDXRef-Cairo_jll-83423d85-b0ee-5818-9007-b63ccbeb887a",
+            "spdxElementId": "SPDXRef-FreeType2_jll-d7e528f0-a631-5988-bf34-fe36492bcfd7",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-GR_jll-d2c73de3-f751-5644-a686-071e5b155ba9"
         },
@@ -4094,7 +5491,27 @@
             "relatedSpdxElement": "SPDXRef-LERC_jll-88015f11-f218-50d7-93a8-a6af411a945d"
         },
         {
+            "spdxElementId": "SPDXRef-b450526929615030746974fd622effa333c2c87a",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LERC_jll-88015f11-f218-50d7-93a8-a6af411a945d"
+        },
+        {
             "spdxElementId": "SPDXRef-LERC_jll-88015f11-f218-50d7-93a8-a6af411a945d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Libtiff_jll-89763e89-9b03-5906-acba-b20f662cd828"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-XZ_jll-ffd25f8a-64ca-5728-b0f7-c24cf3aae800"
+        },
+        {
+            "spdxElementId": "SPDXRef-8f5f66cdbf511f7192128eedfe66211271783733",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-XZ_jll-ffd25f8a-64ca-5728-b0f7-c24cf3aae800"
+        },
+        {
+            "spdxElementId": "SPDXRef-XZ_jll-ffd25f8a-64ca-5728-b0f7-c24cf3aae800",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-Libtiff_jll-89763e89-9b03-5906-acba-b20f662cd828"
         },
@@ -4104,8 +5521,18 @@
             "relatedSpdxElement": "SPDXRef-Zstd_jll-3161d3a3-bdf6-5164-811a-617609db77b4"
         },
         {
+            "spdxElementId": "SPDXRef-9a9f59eab237f7454fee1d6ab112a254032540b7",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Zstd_jll-3161d3a3-bdf6-5164-811a-617609db77b4"
+        },
+        {
             "spdxElementId": "SPDXRef-Zstd_jll-3161d3a3-bdf6-5164-811a-617609db77b4",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Libtiff_jll-89763e89-9b03-5906-acba-b20f662cd828"
+        },
+        {
+            "spdxElementId": "SPDXRef-2107e7bc404f11b178cb9724cb371ef704995727",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-Libtiff_jll-89763e89-9b03-5906-acba-b20f662cd828"
         },
         {
@@ -4117,6 +5544,21 @@
             "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-GLFW_jll-0656b61e-2033-5cc2-a64a-77c0f6c09b89"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Libglvnd_jll-7e76a0d4-f3c7-5321-8279-8d96eeed0f29"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_libXext_jll-1082639a-0dae-5f34-9b06-72781eeb8cb3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Libglvnd_jll-7e76a0d4-f3c7-5321-8279-8d96eeed0f29"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_libX11_jll-4f6342f7-b3d2-589e-9d20-edeb45f2b2bc",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Libglvnd_jll-7e76a0d4-f3c7-5321-8279-8d96eeed0f29"
         },
         {
             "spdxElementId": "SPDXRef-Libglvnd_jll-7e76a0d4-f3c7-5321-8279-8d96eeed0f29",
@@ -4209,6 +5651,11 @@
             "relatedSpdxElement": "SPDXRef-GLFW_jll-0656b61e-2033-5cc2-a64a-77c0f6c09b89"
         },
         {
+            "spdxElementId": "SPDXRef-8dfccc7f1aa9d156f12a6e7db599014b805b11f2",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-GLFW_jll-0656b61e-2033-5cc2-a64a-77c0f6c09b89"
+        },
+        {
             "spdxElementId": "SPDXRef-GLFW_jll-0656b61e-2033-5cc2-a64a-77c0f6c09b89",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-GR_jll-d2c73de3-f751-5644-a686-071e5b155ba9"
@@ -4226,6 +5673,361 @@
         {
             "spdxElementId": "SPDXRef-libpng_jll-b53b4c65-9356-5827-b1ea-8c7a1a84506f",
             "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-GR_jll-d2c73de3-f751-5644-a686-071e5b155ba9"
+        },
+        {
+            "spdxElementId": "SPDXRef-Libglvnd_jll-7e76a0d4-f3c7-5321-8279-8d96eeed0f29",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_libxcb_jll-c7cfdc94-dc32-55de-ac96-5a1b8d977c5b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_image_jll-12413925-8142-5f55-bb0e-6d7ca50bb09b"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_jll-2def613f-5ad1-5310-b15b-b15d46f528f5"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_libxcb_jll-c7cfdc94-dc32-55de-ac96-5a1b8d977c5b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_jll-2def613f-5ad1-5310-b15b-b15d46f528f5"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_xcb_util_jll-2def613f-5ad1-5310-b15b-b15d46f528f5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_image_jll-12413925-8142-5f55-bb0e-6d7ca50bb09b"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_xcb_util_image_jll-12413925-8142-5f55-bb0e-6d7ca50bb09b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-xkbcommon_jll-d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_libxcb_jll-c7cfdc94-dc32-55de-ac96-5a1b8d977c5b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-xkbcommon_jll-d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xkeyboard_config_jll-33bec58e-1273-512f-9401-5d533626f822"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xkbcomp_jll-35661453-b289-5fab-8a00-3d9160c6a3a4"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_libxkbfile_jll-cc61e674-0454-545c-8b26-ed2c68acab7a"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_libX11_jll-4f6342f7-b3d2-589e-9d20-edeb45f2b2bc",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_libxkbfile_jll-cc61e674-0454-545c-8b26-ed2c68acab7a"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_libxkbfile_jll-cc61e674-0454-545c-8b26-ed2c68acab7a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xkbcomp_jll-35661453-b289-5fab-8a00-3d9160c6a3a4"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_xkbcomp_jll-35661453-b289-5fab-8a00-3d9160c6a3a4",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xkeyboard_config_jll-33bec58e-1273-512f-9401-5d533626f822"
+        },
+        {
+            "spdxElementId": "SPDXRef-f8b49c7c45b400e3f5c4002d19645d4b88712c0c",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xkeyboard_config_jll-33bec58e-1273-512f-9401-5d533626f822"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_xkeyboard_config_jll-33bec58e-1273-512f-9401-5d533626f822",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-xkbcommon_jll-d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Wayland_jll-a2964d1f-97da-50d4-b82a-358c7fce9d89"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-EpollShim_jll-2702e6a9-849d-5ed8-8c21-79e8b8f9ee43"
+        },
+        {
+            "spdxElementId": "SPDXRef-EpollShim_jll-2702e6a9-849d-5ed8-8c21-79e8b8f9ee43",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Wayland_jll-a2964d1f-97da-50d4-b82a-358c7fce9d89"
+        },
+        {
+            "spdxElementId": "SPDXRef-XML2_jll-02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Wayland_jll-a2964d1f-97da-50d4-b82a-358c7fce9d89"
+        },
+        {
+            "spdxElementId": "SPDXRef-Expat_jll-2e619515-83b5-522b-bb60-26c02a35a201",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Wayland_jll-a2964d1f-97da-50d4-b82a-358c7fce9d89"
+        },
+        {
+            "spdxElementId": "SPDXRef-Libffi_jll-e9f186c6-92d2-5b65-8a66-fee21dc1b490",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Wayland_jll-a2964d1f-97da-50d4-b82a-358c7fce9d89"
+        },
+        {
+            "spdxElementId": "SPDXRef-Wayland_jll-a2964d1f-97da-50d4-b82a-358c7fce9d89",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-xkbcommon_jll-d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Wayland_protocols_jll-2381bf8a-dfd0-557d-9999-79630e7b1b91"
+        },
+        {
+            "spdxElementId": "SPDXRef-f42f9d226c70f0bc88e5f897d914d9de1ac2ce03",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Wayland_protocols_jll-2381bf8a-dfd0-557d-9999-79630e7b1b91"
+        },
+        {
+            "spdxElementId": "SPDXRef-Wayland_protocols_jll-2381bf8a-dfd0-557d-9999-79630e7b1b91",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-xkbcommon_jll-d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
+        },
+        {
+            "spdxElementId": "SPDXRef-xkbcommon_jll-d8fb68d0-12a3-5cfd-a85a-d49703b185fd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-Fontconfig_jll-a3f928ae-7b40-5064-980b-68af3947d34b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_libXrender_jll-ea2f1a96-1ddc-540d-b46f-429655e07cfa",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Vulkan_Loader_jll-a44049a8-05dd-5a78-86c9-5fde0876e88c"
+        },
+        {
+            "spdxElementId": "SPDXRef-Wayland_jll-a2964d1f-97da-50d4-b82a-358c7fce9d89",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Vulkan_Loader_jll-a44049a8-05dd-5a78-86c9-5fde0876e88c"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_libX11_jll-4f6342f7-b3d2-589e-9d20-edeb45f2b2bc",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Vulkan_Loader_jll-a44049a8-05dd-5a78-86c9-5fde0876e88c"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_libXrandr_jll-ec84b674-ba8e-5d96-8ba1-2a689ba10484",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Vulkan_Loader_jll-a44049a8-05dd-5a78-86c9-5fde0876e88c"
+        },
+        {
+            "spdxElementId": "SPDXRef-xkbcommon_jll-d8fb68d0-12a3-5cfd-a85a-d49703b185fd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Vulkan_Loader_jll-a44049a8-05dd-5a78-86c9-5fde0876e88c"
+        },
+        {
+            "spdxElementId": "SPDXRef-4b3b2d79556cc3aef6e3d8a234649cc85b91bb87",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Vulkan_Loader_jll-a44049a8-05dd-5a78-86c9-5fde0876e88c"
+        },
+        {
+            "spdxElementId": "SPDXRef-Vulkan_Loader_jll-a44049a8-05dd-5a78-86c9-5fde0876e88c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_libICE_jll-f67eecfb-183a-506d-b269-f58e52b52d7c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_libSM_jll-c834827a-8449-5923-a945-d239c165b7dd"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_libSM_jll-c834827a-8449-5923-a945-d239c165b7dd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-libinput_jll-36db933b-70db-51c0-b978-0f229ee0e533"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-eudev_jll-35ca27e7-8b34-5b7f-bca9-bdc33f59eb06"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-gperf_jll-1a1c6b14-54f6-533d-8383-74cd7377aa70"
+        },
+        {
+            "spdxElementId": "SPDXRef-34b9a5702fe42ddb003e7885ea3ab18b3c108b58",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-gperf_jll-1a1c6b14-54f6-533d-8383-74cd7377aa70"
+        },
+        {
+            "spdxElementId": "SPDXRef-gperf_jll-1a1c6b14-54f6-533d-8383-74cd7377aa70",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-eudev_jll-35ca27e7-8b34-5b7f-bca9-bdc33f59eb06"
+        },
+        {
+            "spdxElementId": "SPDXRef-eudev_jll-35ca27e7-8b34-5b7f-bca9-bdc33f59eb06",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-libinput_jll-36db933b-70db-51c0-b978-0f229ee0e533"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-libevdev_jll-2db6ffa8-e38f-5e21-84af-90c45d0032cc"
+        },
+        {
+            "spdxElementId": "SPDXRef-libevdev_jll-2db6ffa8-e38f-5e21-84af-90c45d0032cc",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-libinput_jll-36db933b-70db-51c0-b978-0f229ee0e533"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-mtdev_jll-009596ad-96f7-51b1-9f1b-5ce2d5e8a71e"
+        },
+        {
+            "spdxElementId": "SPDXRef-mtdev_jll-009596ad-96f7-51b1-9f1b-5ce2d5e8a71e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-libinput_jll-36db933b-70db-51c0-b978-0f229ee0e533"
+        },
+        {
+            "spdxElementId": "SPDXRef-libinput_jll-36db933b-70db-51c0-b978-0f229ee0e533",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_wm_jll-c22f9ab0-d5fe-5066-847c-f4bb1cd4e361"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_xcb_util_jll-2def613f-5ad1-5310-b15b-b15d46f528f5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_wm_jll-c22f9ab0-d5fe-5066-847c-f4bb1cd4e361"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_xcb_util_wm_jll-c22f9ab0-d5fe-5066-847c-f4bb1cd4e361",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-Glib_jll-7746bdde-850d-59dc-9ae8-88ece973131d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_renderutil_jll-0d47668e-0667-5a69-a72c-f761630bfb7e"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_xcb_util_jll-2def613f-5ad1-5310-b15b-b15d46f528f5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_renderutil_jll-0d47668e-0667-5a69-a72c-f761630bfb7e"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_xcb_util_renderutil_jll-0d47668e-0667-5a69-a72c-f761630bfb7e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-OpenSSL_jll-458c3c95-2e84-50aa-8efc-19380b2a3a95",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_libXext_jll-1082639a-0dae-5f34-9b06-72781eeb8cb3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_keysyms_jll-975044d2-76e6-5fbe-bf08-97ce7c6574c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_xcb_util_jll-2def613f-5ad1-5310-b15b-b15d46f528f5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_keysyms_jll-975044d2-76e6-5fbe-bf08-97ce7c6574c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_xcb_util_keysyms_jll-975044d2-76e6-5fbe-bf08-97ce7c6574c7",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_cursor_jll-e920d4aa-a673-5f3a-b3d7-f755a4d47c43"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_xcb_util_renderutil_jll-0d47668e-0667-5a69-a72c-f761630bfb7e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_cursor_jll-e920d4aa-a673-5f3a-b3d7-f755a4d47c43"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_xcb_util_image_jll-12413925-8142-5f55-bb0e-6d7ca50bb09b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_cursor_jll-e920d4aa-a673-5f3a-b3d7-f755a4d47c43"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_xcb_util_jll-2def613f-5ad1-5310-b15b-b15d46f528f5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Xorg_xcb_util_cursor_jll-e920d4aa-a673-5f3a-b3d7-f755a4d47c43"
+        },
+        {
+            "spdxElementId": "SPDXRef-Xorg_xcb_util_cursor_jll-e920d4aa-a673-5f3a-b3d7-f755a4d47c43",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-dc1fe71ef939802ae7490350407bea0f47e5be5f",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56"
+        },
+        {
+            "spdxElementId": "SPDXRef-Qt6Base_jll-c0090381-4147-56d7-9ebc-da0b1113ec56",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-GR_jll-d2c73de3-f751-5644-a686-071e5b155ba9"
+        },
+        {
+            "spdxElementId": "SPDXRef-f1af74bc0a21f699d4974bdceac10d4638e61e74",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-GR_jll-d2c73de3-f751-5644-a686-071e5b155ba9"
         },
         {
@@ -4254,6 +6056,11 @@
             "relatedSpdxElement": "SPDXRef-fzf_jll-214eeab7-80f7-51ab-84ad-2988db7cef09"
         },
         {
+            "spdxElementId": "SPDXRef-1b43124b7d46af53ca1fafbd6ab54c8a8ca51960",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-fzf_jll-214eeab7-80f7-51ab-84ad-2988db7cef09"
+        },
+        {
             "spdxElementId": "SPDXRef-fzf_jll-214eeab7-80f7-51ab-84ad-2988db7cef09",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-JLFzf-1019f520-868f-41f5-a6de-eb00f4b6a39c"
@@ -4270,6 +6077,51 @@
         },
         {
             "spdxElementId": "SPDXRef-Unzip-41fe7b60-77ed-43a1-b4f0-825fd5a5650d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Plots-91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+        },
+        {
+            "spdxElementId": "SPDXRef-Unitful-1986cc42-f94f-5a68-af5c-568840ba703d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-UnitfulLatexify-45397f5d-5981-4c77-b2b3-fc36d6e9b728"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrderedCollections-bac558e1-5e72-5ebc-8fee-abe8a469f55d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Latexify-23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+        },
+        {
+            "spdxElementId": "SPDXRef-Formatting-59287772-0a20-5a39-b81b-1366585eb4c0",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Latexify-23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+        },
+        {
+            "spdxElementId": "SPDXRef-LaTeXStrings-b964fa9f-0449-5b57-a5c2-d3ea65f4040f",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Latexify-23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+        },
+        {
+            "spdxElementId": "SPDXRef-Requires-ae029012-a4dd-5104-9daa-d747884805df",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Latexify-23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Latexify-23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+        },
+        {
+            "spdxElementId": "SPDXRef-Latexify-23fbe1c1-3f47-55db-b15f-69d7ec21a316",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-UnitfulLatexify-45397f5d-5981-4c77-b2b3-fc36d6e9b728"
+        },
+        {
+            "spdxElementId": "SPDXRef-LaTeXStrings-b964fa9f-0449-5b57-a5c2-d3ea65f4040f",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-UnitfulLatexify-45397f5d-5981-4c77-b2b3-fc36d6e9b728"
+        },
+        {
+            "spdxElementId": "SPDXRef-UnitfulLatexify-45397f5d-5981-4c77-b2b3-fc36d6e9b728",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-Plots-91a5bcdd-55d7-5caf-9e0b-520d859cae80"
         },
@@ -4314,62 +6166,7 @@
             "relatedSpdxElement": "SPDXRef-ColorVectorSpace-c3611d14-8923-5661-9e6a-0046d554d3a4"
         },
         {
-            "spdxElementId": "SPDXRef-IrrationalConstants-92d709cd-6900-40b7-9082-c6be49f344b6",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-SpecialFunctions-276daf66-3868-5448-9aa4-cd146d93841b"
-        },
-        {
-            "spdxElementId": "SPDXRef-Compat-34da2185-b29b-5c13-b0c7-acf172513d20",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-ChainRulesCore-d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-        },
-        {
-            "spdxElementId": "SPDXRef-ChainRulesCore-d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-SpecialFunctions-276daf66-3868-5448-9aa4-cd146d93841b"
-        },
-        {
-            "spdxElementId": "SPDXRef-IrrationalConstants-92d709cd-6900-40b7-9082-c6be49f344b6",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688"
-        },
-        {
-            "spdxElementId": "SPDXRef-ChainRulesCore-d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688"
-        },
-        {
-            "spdxElementId": "SPDXRef-ChangesOfVariables-9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688"
-        },
-        {
-            "spdxElementId": "SPDXRef-DocStringExtensions-ffbed154-4ef7-542d-bbb7-c09d3a79fcae",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688"
-        },
-        {
-            "spdxElementId": "SPDXRef-InverseFunctions-3587e190-3f89-42d0-90ee-14403ec27112",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688"
-        },
-        {
-            "spdxElementId": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-SpecialFunctions-276daf66-3868-5448-9aa4-cd146d93841b"
-        },
-        {
-            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-OpenSpecFun_jll-efe28fd5-8261-553b-a9e1-b2916fc3738e"
-        },
-        {
-            "spdxElementId": "SPDXRef-OpenSpecFun_jll-efe28fd5-8261-553b-a9e1-b2916fc3738e",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-SpecialFunctions-276daf66-3868-5448-9aa4-cd146d93841b"
-        },
-        {
-            "spdxElementId": "SPDXRef-SpecialFunctions-276daf66-3868-5448-9aa4-cd146d93841b",
+            "spdxElementId": "SPDXRef-Requires-ae029012-a4dd-5104-9daa-d747884805df",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-ColorVectorSpace-c3611d14-8923-5661-9e6a-0046d554d3a4"
         },
@@ -4459,6 +6256,16 @@
             "relatedSpdxElement": "SPDXRef-Plots-91a5bcdd-55d7-5caf-9e0b-520d859cae80"
         },
         {
+            "spdxElementId": "SPDXRef-IrrationalConstants-92d709cd-6900-40b7-9082-c6be49f344b6",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688"
+        },
+        {
+            "spdxElementId": "SPDXRef-DocStringExtensions-ffbed154-4ef7-542d-bbb7-c09d3a79fcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688"
+        },
+        {
             "spdxElementId": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-StatsBase-2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
@@ -4507,31 +6314,6 @@
             "spdxElementId": "SPDXRef-Scratch-6c6a2e73-6563-6170-7368-637461726353",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-Plots-91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-        },
-        {
-            "spdxElementId": "SPDXRef-OrderedCollections-bac558e1-5e72-5ebc-8fee-abe8a469f55d",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Latexify-23fbe1c1-3f47-55db-b15f-69d7ec21a316"
-        },
-        {
-            "spdxElementId": "SPDXRef-Formatting-59287772-0a20-5a39-b81b-1366585eb4c0",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Latexify-23fbe1c1-3f47-55db-b15f-69d7ec21a316"
-        },
-        {
-            "spdxElementId": "SPDXRef-LaTeXStrings-b964fa9f-0449-5b57-a5c2-d3ea65f4040f",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Latexify-23fbe1c1-3f47-55db-b15f-69d7ec21a316"
-        },
-        {
-            "spdxElementId": "SPDXRef-Requires-ae029012-a4dd-5104-9daa-d747884805df",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Latexify-23fbe1c1-3f47-55db-b15f-69d7ec21a316"
-        },
-        {
-            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-Latexify-23fbe1c1-3f47-55db-b15f-69d7ec21a316"
         },
         {
             "spdxElementId": "SPDXRef-Latexify-23fbe1c1-3f47-55db-b15f-69d7ec21a316",

--- a/src/PkgToSoftwareBOM.jl
+++ b/src/PkgToSoftwareBOM.jl
@@ -45,6 +45,7 @@ Base.@kwdef struct spdxPackageData
     registrydata::Dict{UUID, Union{Nothing, Missing, PackageRegistryInfo}}
     packagesinsbom::Set{UUID}= Set{UUID}()
     packageInstructions::Dict{UUID, spdxPackageInstructions}
+    artifactsinsbom::Set{String}= Set{String}()
 end
 
 Base.@kwdef struct spdxCreationData

--- a/src/PkgToSoftwareBOM.jl
+++ b/src/PkgToSoftwareBOM.jl
@@ -41,6 +41,7 @@ Base.@kwdef struct spdxPackageInstructions
 end
 
 Base.@kwdef struct spdxPackageData
+    targetplatform::Platform
     packages::Dict{UUID, Pkg.API.PackageInfo}
     registrydata::Dict{UUID, Union{Nothing, Missing, PackageRegistryInfo}}
     packagesinsbom::Set{UUID}= Set{UUID}()
@@ -49,6 +50,7 @@ Base.@kwdef struct spdxPackageData
 end
 
 Base.@kwdef struct spdxCreationData
+    TargetPlatform::Platform= HostPlatform()
     Name::String= "Julia Environment"
     NamespaceURL::Union{AbstractString, Nothing}= nothing
     Creators::Vector{SpdxCreatorV2}= SpdxCreatorV2[SpdxCreatorV2("Tool", "PkgToSoftwareBOM.jl", "")]

--- a/src/PkgToSoftwareBOM.jl
+++ b/src/PkgToSoftwareBOM.jl
@@ -4,10 +4,11 @@ module PkgToSoftwareBOM
 
 using Pkg
 using UUIDs
-using TOML
 using Reexport
 @reexport using SPDX
+using Artifacts
 using RegistryInstances
+using Base.BinaryPlatforms
 
 export spdxCreationData, spdxPackageInstructions
 

--- a/src/packageInfo.jl
+++ b/src/packageInfo.jl
@@ -47,7 +47,7 @@ function resolve_pkgsource!(package::SpdxPackageV2, artifact::Dict{String, Any})
     platform_keys= setdiff(keys(artifact), Set(["download", "git-tree-sha1", "lazy"]))
     if length(platform_keys) > 0
         package.SourceInfo= ""
-        package.SourceInfo= string(package.SourceInfo, "This artifact download was determined using following platform specific parameters.", "\n")
+        package.SourceInfo= string(package.SourceInfo, "The artifact download URL was determined using the following platform specific parameters:", "\n")
         for k in platform_keys
             package.SourceInfo= string(package.SourceInfo, k * ": ", artifact[k], "\n")
         end

--- a/src/packageInfo.jl
+++ b/src/packageInfo.jl
@@ -73,5 +73,5 @@ function resolve_pkgsource!(package::SpdxPackageV2, artifact::Dict{String, Any})
 
     package.HomePage= "NOASSERTION"
 
-        
+    return nothing
 end

--- a/src/spdxBuild.jl
+++ b/src/spdxBuild.jl
@@ -96,6 +96,8 @@ function buildSPDXpackage!(spdxDoc::SpdxDocumentV2, uuid::UUID, builddata::spdxP
                 else
                     push!(spdxDoc.Relationships, SpdxRelationshipV2("$(depid) RUNTIME_DEPENDENCY_OF $(package.SPDXID)"))
                 end
+            elseif ismissing(depid)
+                error("buildSPDXpackage!():  call of buildSPDXpackage!() for an artifact package returned an error")
             end
         end
     end

--- a/src/spdxBuild.jl
+++ b/src/spdxBuild.jl
@@ -65,6 +65,7 @@ function buildSPDXpackage!(spdxDoc::SpdxDocumentV2, uuid::UUID, builddata::spdxP
     push!(package.LicenseInfoFromFiles, SpdxLicenseExpressionV2("NOASSERTION"))
     package.LicenseDeclared= ismissing(packageInstructions) ? SpdxLicenseExpressionV2("NOASSERTION") : packageInstructions.declaredLicense # TODO: Scan source for licenses and/or query Github API
     package.Copyright= ismissing(packageInstructions) ? "NOASSERTION" : packageInstructions.copyright # TODO:  Scan license files for the first line that says "Copyright"?  That would about work.
+    package.Summary= "This is a Julia package, written in the Julia language."
 
     # TODO: Populate Summary with something via a Github API query
     # TODO: Should DetailedDescription be populated with the README?  Or the first 10k characters? Or just a link or path to the README?
@@ -86,8 +87,7 @@ function buildSPDXpackage!(spdxDoc::SpdxDocumentV2, uuid::UUID, builddata::spdxP
     filecheck= isfile.(joinpath.(packagedata.source, filenames))
     if any(filecheck)
         artifact_toml= joinpath(packagedata.source, filenames[findfirst(filecheck)])
-        resolved_artifact_data= select_downloadable_artifacts(artifact_toml; platform= HostPlatform(), include_lazy= true) # Reads (Julia)Artifacts.toml and resolves
-                                                                                                                  # the set of artifacts appropriate to the target platform
+        resolved_artifact_data= select_downloadable_artifacts(artifact_toml; platform= HostPlatform(), include_lazy= true)
         for (artifact_name, artifact) in resolved_artifact_data
             depid= buildSPDXpackage!(spdxDoc, artifact_name, artifact, builddata)
             if depid isa String
@@ -121,7 +121,9 @@ function buildSPDXpackage!(spdxDoc::SpdxDocumentV2, artifact_name::AbstractStrin
     #TODO: package.VerificationCode= spdxpkgverifcode(packagedata.source, packageInstructions) # Verify the artifact is installed (not necessarily true for lazy artifacts). Download if it is not?
     package.LicenseConcluded= SpdxLicenseExpressionV2("NOASSERTION")
     push!(package.LicenseInfoFromFiles, SpdxLicenseExpressionV2("NOASSERTION"))
+    package.LicenseDeclared= SpdxLicenseExpressionV2("NOASSERTION") 
     package.Copyright= "NOASSERTION"  # TODO:  Should there be instructions like for packages?  Scan license files for the first line that says "Copyright"?  That would about work.
+    package.Summary= "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package."
 
     package.Comment= "The SPDX ID field is derived from the Git tree hash that all Julia artifacts are computer to uniquely identify it."
 

--- a/src/spdxBuild.jl
+++ b/src/spdxBuild.jl
@@ -97,11 +97,7 @@ function buildSPDXpackage!(spdxDoc::SpdxDocumentV2, uuid::UUID, builddata::spdxP
         for (artifact_name, artifact) in resolved_artifact_data
             depid= buildSPDXpackage!(spdxDoc, artifact_name, artifact, builddata)
             if depid isa String
-                if haskey(artifact, ["lazy"]) && artifact["lazy"] == true
-                    push!(spdxDoc.Relationships, SpdxRelationshipV2("$(depid) OPTIONAL_DEPENDENCY_OF $(package.SPDXID)"))
-                else
-                    push!(spdxDoc.Relationships, SpdxRelationshipV2("$(depid) RUNTIME_DEPENDENCY_OF $(package.SPDXID)"))
-                end
+                push!(spdxDoc.Relationships, SpdxRelationshipV2("$(depid) RUNTIME_DEPENDENCY_OF $(package.SPDXID)"))
             elseif ismissing(depid)
                 error("buildSPDXpackage!():  call of buildSPDXpackage!() for an artifact package returned an error")
             end
@@ -132,6 +128,9 @@ function buildSPDXpackage!(spdxDoc::SpdxDocumentV2, artifact_name::AbstractStrin
     package.LicenseDeclared= SpdxLicenseExpressionV2("NOASSERTION") 
     package.Copyright= "NOASSERTION"  # TODO:  Should there be instructions like for packages?  Scan license files for the first line that says "Copyright"?  That would about work.
     package.Summary= "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package."
+    if haskey(artifact, ["lazy"]) && artifact["lazy"] == true
+        package.Summary*= "\nThis is a lazy artifact that is not downloaded when the parent Julia package is installed. It will be downloaded when needed."
+    end
 
     package.Comment= "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
 

--- a/src/spdxBuild.jl
+++ b/src/spdxBuild.jl
@@ -133,7 +133,7 @@ function buildSPDXpackage!(spdxDoc::SpdxDocumentV2, artifact_name::AbstractStrin
     package.Copyright= "NOASSERTION"  # TODO:  Should there be instructions like for packages?  Scan license files for the first line that says "Copyright"?  That would about work.
     package.Summary= "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package."
 
-    package.Comment= "The SPDX ID field is derived from the Git tree hash that all Julia artifacts are computer to uniquely identify it."
+    package.Comment= "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
 
     push!(spdxDoc.Packages, package)
     push!(builddata.artifactsinsbom, git_tree_sha1)

--- a/src/spdxBuild.jl
+++ b/src/spdxBuild.jl
@@ -91,10 +91,8 @@ function buildSPDXpackage!(spdxDoc::SpdxDocumentV2, uuid::UUID, builddata::spdxP
     end
 
     # Check for artifacts and add them
-    filenames= ["Artifacts.toml", "JuliaArtifacts.toml"]
-    filecheck= isfile.(joinpath.(packagedata.source, filenames))
-    if any(filecheck)
-        artifact_toml= joinpath(packagedata.source, filenames[findfirst(filecheck)])
+    artifact_toml= find_artifacts_toml(packagedata.source)
+    if artifact_toml isa String
         resolved_artifact_data= select_downloadable_artifacts(artifact_toml; platform= builddata.targetplatform, include_lazy= true)
         for (artifact_name, artifact) in resolved_artifact_data
             depid= buildSPDXpackage!(spdxDoc, artifact_name, artifact, builddata)

--- a/src/spdxBuild.jl
+++ b/src/spdxBuild.jl
@@ -20,8 +20,10 @@ function generateSPDX(docData::spdxCreationData= spdxCreationData(), sbomRegistr
 
     # Add any creator comments from docData and then append the Traget Platform Information
     ismissing(docData.CreatorComment) || (spdxDoc.CreationInfo.CreatorComment= docData.CreatorComment)
-    (spdxDoc.CreationInfo.CreatorComment isa String) && (spdxDoc.CreationInfo.CreatorComment*= "\n")
-    ismissing(spdxDoc.CreationInfo.CreatorComment) && (spdxDoc.CreationInfo.CreatorComment= "")
+
+    if (ismissing(spdxDoc.CreationInfo.CreatorComment))  spdxDoc.CreationInfo.CreatorComment= ""
+                                                   else  spdxDoc.CreationInfo.CreatorComment*= "\n" end
+
     spdxDoc.CreationInfo.CreatorComment*= string("Target Platform: ", string(docData.TargetPlatform))
 
     ismissing(docData.DocumentComment) || (spdxDoc.DocumentComment= docData.DocumentComment)

--- a/src/spdxBuild.jl
+++ b/src/spdxBuild.jl
@@ -18,7 +18,7 @@ function generateSPDX(docData::spdxCreationData= spdxCreationData(), sbomRegistr
     end
     setcreationtime!(spdxDoc)
 
-    # Add any creator comments from docData and then append the Traget Platform Information
+    # Add any creator comments from docData and then append the Target Platform information
     ismissing(docData.CreatorComment) || (spdxDoc.CreationInfo.CreatorComment= docData.CreatorComment)
 
     if (ismissing(spdxDoc.CreationInfo.CreatorComment))  spdxDoc.CreationInfo.CreatorComment= ""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Pkg
 using PkgToSoftwareBOM
 using Test
 using UUIDs
+using Base.BinaryPlatforms
 
 @testset "PkgToSoftwareBOM.jl" begin
     # Function issetequal doesn't work with vectors of SpdxRelationshipV2
@@ -77,7 +78,7 @@ using UUIDs
 
         @test sbom.Name == SPDX_docCreation.Name
         @test isvectorsetequal(sbom.CreationInfo.Creator, SPDX_docCreation.Creators)
-        @test sbom.CreationInfo.CreatorComment == SPDX_docCreation.CreatorComment
+        @test sbom.CreationInfo.CreatorComment == SPDX_docCreation.CreatorComment * string("\nTarget Platform: ", string(HostPlatform()))
         @test occursin(SPDX_docCreation.DocumentComment, sbom.DocumentComment)
         @test sbom.Namespace.URI == SPDX_docCreation.NamespaceURL
 
@@ -118,7 +119,7 @@ using UUIDs
         @test ismissing(sbom.CreationInfo.LicenseListVersion)
         @test length(sbom.CreationInfo.Creator) == 1 && sbom.CreationInfo.Creator[1] == SpdxCreatorV2("Tool: PkgToSoftwareBOM.jl")
         @test !ismissing(sbom.CreationInfo.Created)
-        @test ismissing(sbom.CreationInfo.CreatorComment)
+        @test sbom.CreationInfo.CreatorComment == string("Target Platform: ", string(HostPlatform()))
         @test occursin("DummyRegistry", sbom.DocumentComment) && occursin("General registry", sbom.DocumentComment)
         @test isempty(sbom.Files)
         @test isempty(sbom.Snippets)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -142,7 +142,7 @@ using UUIDs
         @test all(isequal.(getproperty.(sbom.Packages, :LicenseDeclared), [SpdxSimpleLicenseExpressionV2("NOASSERTION")]))
         @test all(ismissing.(getproperty.(sbom.Packages, :LicenseComments)))
         @test all(isequal.(getproperty.(sbom.Packages, :Copyright), "NOASSERTION"))
-        @test all(ismissing.(getproperty.(sbom.Packages, :Summary)))
+        @test all(isequal.(getproperty.(sbom.Packages, :Summary), "This is a Julia package, written in the Julia language."))
         @test all(ismissing.(getproperty.(sbom.Packages, :DetailedDescription)))
         @test all(isequal.(getproperty.(sbom.Packages, :Comment), "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."))
         @test all(isempty.(getproperty.(sbom.Packages, :ExternalReferences)))


### PR DESCRIPTION
Resolves #2 . Resolves #22 .

All artifacts (including lazy artifacts) are included in SBOM generation.  The artifact versions are resolved to target the platform that Julia is running on. As a happy by-product of this, the version of julia that was used to generate the SBOM is now documented. An advanced user could change the target platform to another OS and CPU architecture, but this has not been tested.