### PR TITLE
Don't require custom registries to have a registry description

### DIFF
--- a/src/PkgToSoftwareBOM.jl
+++ b/src/PkgToSoftwareBOM.jl
@@ -19,7 +19,7 @@ Base.@kwdef struct PackageRegistryInfo
     registryName::String
     registryURL::String
     registryPath::String
-    registryDescription::String
+    registryDescription::Union{String, Nothing}
     packageUUID::UUID
     packageName::String
     packageVersion::VersionNumber


### PR DESCRIPTION
The Julia General registry has a registry description in its `Registry.toml` file: https://github.com/JuliaRegistries/General/blob/master/Registry.toml

However, custom or private registries do not necessarily have registry descriptions in their `Registry.toml` files.

Currently, PkgToSoftwareBOM will throw an error if you try to use it with a registry that lacks a registry description.

This PR fixes that error.