### PR TITLE
Add purl identifiers for packages.

### DIFF
--- a/src/spdxBuild.jl
+++ b/src/spdxBuild.jl
@@ -87,7 +87,7 @@ function buildSPDXpackage!(spdxDoc::SpdxDocumentV2, uuid::UUID, builddata::spdxP
     package.VerificationCode= spdxpkgverifcode(packagedata.source, packageInstructions)
     package.Copyright= ismissing(packageInstructions) ? "NOASSERTION" : packageInstructions.copyright # TODO:  Scan license files for the first line that says "Copyright"?  That would about work.
     package.Summary= "This is a Julia package, written in the Julia language."
-
+    package.ExternalReferences=[SpdxPackageExternalReferenceV2("PACKAGE-MANAGER", "purl", "pkg:julia/$(packagedata.name)@$(packagedata.version)?uuid=$(uuid)")]
     # TODO: Populate Summary with something via a Github API query
     # TODO: Should DetailedDescription be populated with the README?  Or the first 10k characters? Or just a link or path to the README?
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,6 +101,7 @@ using Base.BinaryPlatforms
         @test SPDX_pkg.LicenseDeclared== myLicense
         @test SPDX_pkg.Copyright== myPackage_instr.copyright
         @test SPDX_pkg.Name== package_name
+        @test SPDX_pkg.ExternalReferences[1].Locator == "pkg:julia/$(SPDX_pkg.Name)@$(SPDX_pkg.Version)?uuid=47358f48-d834-4249-91f5-f6185eb3d540"
     end
 
     @testset "Repo Track + Dual registries" begin
@@ -160,7 +161,6 @@ using Base.BinaryPlatforms
         @test all(isequal.(getproperty.(sbom.Packages, :Summary), "This is a Julia package, written in the Julia language."))
         @test all(ismissing.(getproperty.(sbom.Packages, :DetailedDescription)))
         @test all(isequal.(getproperty.(sbom.Packages, :Comment), "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."))
-        @test all(isempty.(getproperty.(sbom.Packages, :ExternalReferences)))
         @test all(isempty.(getproperty.(sbom.Packages, :Attributions)))
         @test all(ismissing.(getproperty.(sbom.Packages, :PrimaryPurpose)))
         @test all(ismissing.(getproperty.(sbom.Packages, :ReleaseDate)))


### PR DESCRIPTION
As https://github.com/package-url/purl-spec/pull/540 seems good to go, and @mbauman [mentioned](https://github.com/package-url/purl-spec/pull/540#issuecomment-3329717228) to start using these purls in security advisories.