### PR TITLE
Add stdlibs to SBOM

### DIFF
--- a/src/Registry.jl
+++ b/src/Registry.jl
@@ -77,8 +77,8 @@ function populate_registryinfo(uuid::UUID, package::Pkg.API.PackageInfo, registr
 
     # TODO: Resolve the correct Compat and Deps for this version
 
-    # If actively tracking the registry, verify that the version exists in this registry
-    package.is_tracking_registry && !haskey(registryPkgData.version_info, package.version) && return missing
+    # Verify that the version exists in this registry
+    haskey(registryPkgData.version_info, package.version) || return missing
 
     packageSubdir= isnothing(registryPkgData.subdir) ? "" : registryPkgData.subdir
 

--- a/src/Registry.jl
+++ b/src/Registry.jl
@@ -84,7 +84,7 @@ function populate_registryinfo(uuid::UUID, package::Pkg.API.PackageInfo, registr
 
     tree_hash= haskey(registryPkgData.version_info, package.version) ? treehash(registryPkgData, package.version) : nothing
 
-    # Verify the tree hash in the registry matches the hash in the package. This check usually (always?) fails with an stdlib, even if it is tracked in the registry.
+    # Verify the tree hash in the registry matches the hash in the package. This check usually (always?) fails with an stdlib, even if it is tracked in the registry, becuase package.tree_hash is nothing.
     if !is_stdlib(uuid)
         package.is_tracking_registry && string(tree_hash) !== package.tree_hash && error("Tree hash of $(package.name) v$(string(package.version)) does not match registry:  $(string(package.tree_hash)) (Package) vs. $(treehash(registryPkgData, package.version)) (Registry)")
     end

--- a/src/packageInfo.jl
+++ b/src/packageInfo.jl
@@ -12,7 +12,7 @@ function resolve_pkgsource!(uuid::UUID, package::SpdxPackageV2, packagedata::Pkg
     if packagedata.is_tracking_registry && !isnothing(registrydata) && !ismissing(registrydata)
         # Simplest and most common case is if you are tracking a registered package
         # stdlibs that aren't actually in the registry tend to lie and say they are tracking, hence the additional checks
-        repo_download= SpdxDownloadLocationV2("git+$(registrydata.packageURL)@$(packagedata.tree_hash)$(isempty(registrydata.packageSubdir) ? "" : "#"*registrydata.packageSubdir)")
+        repo_download= SpdxDownloadLocationV2("git+$(registrydata.packageURL)@$(registrydata.packageTreeHash)$(isempty(registrydata.packageSubdir) ? "" : "#"*registrydata.packageSubdir)")
         
         if is_stdlib(uuid)
             package.SourceInfo= "This package is part of the Julia standard library.\n"
@@ -65,7 +65,7 @@ function resolve_pkgsource!(uuid::UUID, package::SpdxPackageV2, packagedata::Pkg
         package.Supplier= SpdxCreatorV2("NOASSERTION")
     elseif is_stdlib(uuid) # That's not being tracked in a registry
         package.DownloadLocation= SpdxDownloadLocationV2("git+https://github.com/JuliaLang/julia.git@v$(string(VERSION))#stdlib/$(package.Name)")
-        package.SourceInfo= "This package is part of the Julia standard library and is located in the Julia source code tree.\n"
+        package.SourceInfo= "This package is part of the Julia standard library and is located in the Julia source code tree."
         package.HomePage= "https://julialang.org"
         package.Supplier= SpdxCreatorV2("Organization", "JuliaLang", "")
     else

--- a/src/packageInfo.jl
+++ b/src/packageInfo.jl
@@ -1,20 +1,26 @@
 # SPDX-License-Identifier: MIT
 
 ###############################
-function resolve_pkgsource!(package::SpdxPackageV2, packagedata::Pkg.API.PackageInfo, registrydata::Union{Nothing, Missing, PackageRegistryInfo})
+function resolve_pkgsource!(uuid::UUID, package::SpdxPackageV2, packagedata::Pkg.API.PackageInfo, registrydata::Union{Nothing, Missing, PackageRegistryInfo})
     # The location of the SPDX package's source code depend on whether Pkg is tracking the package via:
-    #   1) A package registry
+    #   1) A package listed in the registry; Some stdlibs are tracked in the General registry, some are not.
     #   2) Connecting directly with a git repository
     #   3) Source code on a locally accessible storage device (i.e. no source control)
-    #   4) Is the locally stored code actually a registered package or code from a repository that is under development?
+    #   4) A stdlib that is not tracked in the registry
+    #   5) Is the locally stored code actually a registered package or code from a repository that is under development?
 
-    if packagedata.is_tracking_registry
+    if packagedata.is_tracking_registry && !isnothing(registrydata) && !ismissing(registrydata)
         # Simplest and most common case is if you are tracking a registered package
+        # stdlibs that aren't actually in the registry tend to lie and say they are tracking, hence the additional checks
         repo_download= SpdxDownloadLocationV2("git+$(registrydata.packageURL)@$(packagedata.tree_hash)$(isempty(registrydata.packageSubdir) ? "" : "#"*registrydata.packageSubdir)")
         
+        if is_stdlib(uuid)
+            package.SourceInfo= "This package is part of the Julia standard library.\n"
+        end
+
         if isnothing(registrydata.packageserverURL)
             package.DownloadLocation= repo_download
-            package.SourceInfo= "Download Location is supplied by the $(registrydata.registryName) registry:\n$(registrydata.registryURL)"
+            package.SourceInfo= package.SourceInfo * "Download Location is supplied by the $(registrydata.registryName) registry:\n$(registrydata.registryURL)"
             package.SourceInfo= package.SourceInfo * "\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>"
             package.Supplier= SpdxCreatorV2("NOASSERTION")
         else
@@ -24,9 +30,15 @@ function resolve_pkgsource!(package::SpdxPackageV2, packagedata::Pkg.API.Package
             else
                 package.Supplier= SpdxCreatorV2("NOASSERTION")
             end
-            package.SourceInfo= "Download is a compressed tarball, supplied from a package server, rather than the package source respository."
+            package.SourceInfo= package.SourceInfo * "Download is a compressed tarball, supplied from a package server, rather than the package source respository."
         end
-        package.HomePage= registrydata.packageURL
+
+        if is_stdlib(uuid)
+            package.HomePage= "https://julialang.org"
+            package.Supplier= SpdxCreatorV2("Organization", "JuliaLang", "")
+        else
+            package.HomePage= registrydata.packageURL
+        end
     elseif packagedata.is_tracking_repo
         # Next simplest case is if you are directly tracking a repository
         # TODO: Extract the subdirectory information if it exists. Can't find it in packagedata.
@@ -51,6 +63,11 @@ function resolve_pkgsource!(package::SpdxPackageV2, packagedata::Pkg.API.Package
             package.FileName= packagedata.source
         end
         package.Supplier= SpdxCreatorV2("NOASSERTION")
+    elseif is_stdlib(uuid) # That's not being tracked in a registry
+        package.DownloadLocation= SpdxDownloadLocationV2("git+https://github.com/JuliaLang/julia.git@v$(string(VERSION))#stdlib/$(package.Name)")
+        package.SourceInfo= "This package is part of the Julia standard library and is located in the Julia source code tree.\n"
+        package.HomePage= "https://julialang.org"
+        package.Supplier= SpdxCreatorV2("Organization", "JuliaLang", "")
     else
         # This should not happen unless there has been a breaking change in Pkg
         error("PkgToSBOM.resolve_pkgsource!():  Unable to resolve. Maybe the Pkg source has changed in a breaking way?")

--- a/src/spdxBuild.jl
+++ b/src/spdxBuild.jl
@@ -74,15 +74,12 @@ function buildSPDXpackage!(spdxDoc::SpdxDocumentV2, uuid::UUID, builddata::spdxP
     # Check if this package already exists in the SBOM
     (uuid in builddata.packagesinsbom) && (return package.SPDXID)
 
-    # Check if it's a standard library
-    is_stdlib(uuid) && return nothing
-
     @logmsg Logging.LogLevel(-50) "******* Entering package $(packagedata.name) *******"
     
     package.Name= packagedata.name
     package.Version= string(packagedata.version)
     package.Originator= ismissing(packageInstructions) ?  SpdxCreatorV2("NOASSERTION") : packageInstructions.originator  # TODO: Use the person or group that hosts the repo on Github. Is there an API to query?    
-    resolve_pkgsource!(package, packagedata, registrydata)
+    resolve_pkgsource!(uuid, package, packagedata, registrydata)
     resolve_pkglicense!(package, packagedata.source, packageInstructions, builddata.licenseScan)
     package.VerificationCode= spdxpkgverifcode(packagedata.source, packageInstructions)
     package.Copyright= ismissing(packageInstructions) ? "NOASSERTION" : packageInstructions.copyright # TODO:  Scan license files for the first line that says "Copyright"?  That would about work.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,14 @@ using Base.BinaryPlatforms
         sbom = generateSPDX(spdxCreationData(find_artifactsource= true))
         # The SBOM is too big and complex to check everything, but we can check some things
         root_relationships= filter(r -> r.RelationshipType=="DESCRIBES", sbom.Relationships)
-        @test issetequal(getproperty.(root_relationships, :RelatedSPDXID), ["SPDXRef-PkgToSoftwareBOM-6254a0f9-6143-4104-aa2e-fd339a2830a6", "SPDXRef-SPDX-47358f48-d834-4249-91f5-f6185eb3d540", "SPDXRef-RegistryInstances-2792f1a3-b283-48e8-9a74-f99dce5104f3", "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69", "SPDXRef-LicenseCheck-726dbf0d-6eb6-41af-b36c-cd770e0f00cc"])
+        @test issetequal(getproperty.(root_relationships, :RelatedSPDXID), 
+                           ["SPDXRef-Downloads-f43a241f-c20a-4ad4-852c-f6b1247861c6",    "SPDXRef-Pkg-44cfe95a-1eb2-52ea-b672-e2afdf69b78f", 
+                            "SPDXRef-Test-8dfed614-e22c-5e08-85e1-65c5234f0b40",         "SPDXRef-UUIDs-cf7118a7-6976-5b1a-9a39-7adc72f591a4", 
+                            "SPDXRef-Artifacts-56f22d72-fd6d-98f1-02f0-08ddc0907c33",    "SPDXRef-RegistryInstances-2792f1a3-b283-48e8-9a74-f99dce5104f3", 
+                            "SPDXRef-LicenseCheck-726dbf0d-6eb6-41af-b36c-cd770e0f00cc", "SPDXRef-Logging-56ddb016-857b-54e1-b83d-db4d58db5568", 
+                            "SPDXRef-SPDX-47358f48-d834-4249-91f5-f6185eb3d540",         "SPDXRef-PkgToSoftwareBOM-6254a0f9-6143-4104-aa2e-fd339a2830a6", 
+                            "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69"]
+                        )
         @test !isempty(filter(p -> p.SPDXID == "SPDXRef-PkgToSoftwareBOM-6254a0f9-6143-4104-aa2e-fd339a2830a6", sbom.Packages))
         @test !isempty(filter(p -> p.SPDXID == "SPDXRef-SPDX-47358f48-d834-4249-91f5-f6185eb3d540", sbom.Packages))
         @test !isempty(filter(isequal(SpdxRelationshipV2("SPDXRef-SPDX-47358f48-d834-4249-91f5-f6185eb3d540 DEPENDENCY_OF SPDXRef-PkgToSoftwareBOM-6254a0f9-6143-4104-aa2e-fd339a2830a6")), sbom.Relationships))


### PR DESCRIPTION
Resolves #38 

Previously when an stdlib was encountered PkgToSoftwareBOM would ignore it. Properly processing stdlibs requires some special code exceptions which I didn't get to in the past. 