### PR TITLE
Replace _ with - in SPDXID.

### DIFF
--- a/src/spdxBuild.jl
+++ b/src/spdxBuild.jl
@@ -69,7 +69,8 @@ function buildSPDXpackage!(spdxDoc::SpdxDocumentV2, uuid::UUID, builddata::spdxP
     packagedata= builddata.packages[uuid]
     registrydata= builddata.registrydata[uuid]
     packageInstructions= get(builddata.packageInstructions, uuid, missing)
-    package= SpdxPackageV2("SPDXRef-$(packagedata.name)-$(uuid)")
+    # SPDX IDs only allow [a-zA-Z0-9.-], but Julia package names (e.g. Foo_jll) may contain underscores
+    package= SpdxPackageV2("SPDXRef-$(replace(packagedata.name, "_" => "-"))-$(uuid)")
 
     # Check if this package already exists in the SBOM
     (uuid in builddata.packagesinsbom) && (return package.SPDXID)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,7 +224,8 @@ using Base.BinaryPlatforms
 
     @testset "Artifact Tests" begin
         using MWETestSBOM_LazyArtifact
-        spdxid= "SPDXRef-MWETestSBOM_LazyArtifact-1c66bc15-73f4-4e94-8c80-c77ca7b88078"
+        # Underscores are not valid in an SPDXID, so they are replaced with dashes
+        spdxid= "SPDXRef-MWETestSBOM-LazyArtifact-1c66bc15-73f4-4e94-8c80-c77ca7b88078"
 
         download_artifact()
         sbom_downloaded= generateSPDX(spdxCreationData(rootpackages= filter(p-> (p.first in ["MWETestSBOM_LazyArtifact"]), Pkg.project().dependencies)), ["DummyRegistry", "General"]);
@@ -240,6 +241,8 @@ using Base.BinaryPlatforms
         @test SPDX.compare_b(sbom_downloaded.Packages, sbom_lazy.Packages; skipproperties= [:VerificationCode])
         ## Compare the Package verification codes
         packageindex= findfirst(getproperty.(sbom_lazy.Packages, :Name).=="MWETestSBOM_LazyArtifact")
+        @test sbom_lazy.Packages[packageindex].SPDXID == spdxid
+        @test !occursin("_", sbom_lazy.Packages[packageindex].SPDXID)
         artifactindex= findfirst(getproperty.(sbom_lazy.Packages, :Name).=="socrates")
         @test  ismissing(      sbom_lazy.Packages[artifactindex].VerificationCode)
         @test !ismissing(sbom_downloaded.Packages[artifactindex].VerificationCode)


### PR DESCRIPTION
Jll packages like Foo_jll.jl contain underscores, which currently end up in the SPDXID. However the [spec](https://spdx.github.io/spdx-spec/v2.3/package-information/#7.2) says:

> "SPDXRef-"[idstring] where [idstring] is a unique string containing letters, numbers, ., and/or -.

This prevented uploading the resulting SBOM to external tooling. I haven't checked for other spec issues, but after manually replacing the underscores, the upload worked.

@SamuraiAku 