### PR TITLE
Update SPDX.jl compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgToSoftwareBOM"
 uuid = "6254a0f9-6143-4104-aa2e-fd339a2830a6"
 authors = ["Simon Avery <savery@ieee.org> and contributors"]
-version = "0.1.18"
+version = "0.1.19"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -15,7 +15,7 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Downloads= "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
 [compat]
-SPDX = "0.4"
+SPDX = "0.4, 0.5"
 RegistryInstances = "0.1"
 Reexport = "1"
 LicenseCheck = "0.2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,10 +53,10 @@ using Base.BinaryPlatforms
         root_relationships= filter(r -> r.RelationshipType=="DESCRIBES", sbom_with_exclusions.Relationships)
         @test issetequal(getproperty.(root_relationships, :RelatedSPDXID), ["SPDXRef-PkgToSoftwareBOM-6254a0f9-6143-4104-aa2e-fd339a2830a6"])
         @test !isnothing(filter(p -> p.SPDXID == "SPDXRef-PkgToSoftwareBOM-6254a0f9-6143-4104-aa2e-fd339a2830a6", sbom.Packages))
-        # Dummy Registry, which is checked first, has only an old version of DataStructures (0.17.20) whereas SPDX needs at least 0.18
+        # Dummy Registry, which is checked first, has an old version of TimeZones (1.0.1) whereas SPDX uses the latest (1.22.2 or later)
         # Verify that the package in the SBOM did not choose that version for the SBOM
-        DataStructuresPkg= filter(p-> occursin("SPDXRef-DataStructures", p.SPDXID), sbom.Packages)
-        @test VersionNumber(DataStructuresPkg[1].Version) >= v"0.18"
+        TimeZonesPkg= filter(p-> occursin("SPDXRef-TimeZones", p.SPDXID), sbom.Packages)
+        @test VersionNumber(TimeZonesPkg[1].Version) >= v"1.1"
 
         # Use the package server for downloads
         sbom_with_packageserver = generateSPDX(spdxCreationData(use_packageserver= true))


### PR DESCRIPTION
Allow PkgToSoftwareBOM to use v0.4 or v0.5 of SPDX.jl