### PR TITLE
Do not abort if a package (version) is not in the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.1.20
+* Resolved [#41](https://github.com/SamuraiAku/PkgToSoftwareBOM.jl/issues/41), PkgToSoftwareBOM now works with Julia 1.12+ workspaces. The SBOM describes the dependencies of every workspace member project, not just those reachable from the top level project
+* Added the public helper `PkgToSoftwareBOM.environment_rootpackages`, the workspace-aware replacement for `Pkg.project().dependencies`, for selecting the root packages of the SBOM
+
 ## 0.1.19
 * PkgToSoftwareBOM now selects between SPDX.jl v0.4 and v0.5 at the package manager's discretion
     * SPDX v0.5 uses JSON v1.x, SPDX v0.4 uses JSON.jl v0.19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.1.21
+* An installed package whose version is not found in the specified registries no longer aborts the whole SBOM. This commonly happens when a package is updated in the environment while the local registry copy lags behind.
+    * When the package's UUID is registered but the installed version is not, the package is described precisely from the registry's repository and the installed package's git tree hash, with a note that the version was not found in the registry.
+    * When the package is not registered at all, it is recorded with limited source information (download location NOASSERTION and a note in SourceInfo).
+    * In both cases a warning is logged.
+
 ## 0.1.20
 * Resolved [#41](https://github.com/SamuraiAku/PkgToSoftwareBOM.jl/issues/41), PkgToSoftwareBOM now works with Julia 1.12+ workspaces. The SBOM describes the dependencies of every workspace member project, not just those reachable from the top level project
 * Added the public helper `PkgToSoftwareBOM.environment_rootpackages`, the workspace-aware replacement for `Pkg.project().dependencies`, for selecting the root packages of the SBOM

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgToSoftwareBOM"
 uuid = "6254a0f9-6143-4104-aa2e-fd339a2830a6"
 authors = ["Simon Avery <savery@ieee.org> and contributors"]
-version = "0.1.19"
+version = "0.1.20"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/README.md
+++ b/README.md
@@ -81,11 +81,15 @@ To create an SBOM of your entire environment type:
 
 `sbom= generateSPDX()`
 
+This also works for [Julia 1.12+ workspaces](https://pkgdocs.julialang.org/v1/toml-files/#The-%5Bworkspace%5D-section): the SBOM describes the dependencies of the top level project together with those of every workspace member project.
+
 If you wish to not include PkgToSoftwareBOM and SPDX (or some other package) in your SBOM:
 
 ```julia
-sbom= generateSPDX(spdxCreationData(rootpackages= filter(p-> !(p.first in ["PkgToSoftwareBOM", "SPDX"]), Pkg.project().dependencies)));
+sbom= generateSPDX(spdxCreationData(rootpackages= filter(p-> !(p.first in ["PkgToSoftwareBOM", "SPDX"]), PkgToSoftwareBOM.environment_rootpackages())));
 ```
+
+`PkgToSoftwareBOM.environment_rootpackages()` returns the direct dependencies of the active environment (including any workspace member projects) as a `Dict{String, UUID}`. For a single project environment it is equivalent to `Pkg.project().dependencies`.
 
 To write the SBOM to file:
 ```julia

--- a/src/PkgToSoftwareBOM.jl
+++ b/src/PkgToSoftwareBOM.jl
@@ -15,6 +15,8 @@ using Downloads
 
 export spdxCreationData, spdxPackageInstructions
 
+VERSION >= v"1.11.0-DEV.469" && "public environment_rootpackages" |> Meta.parse |> eval
+
 Base.@kwdef struct PackageRegistryInfo
     registryName::String
     registryURL::String
@@ -65,7 +67,7 @@ Base.@kwdef struct spdxCreationData
     Creators::Vector{SpdxCreatorV2}= SpdxCreatorV2[SpdxCreatorV2("Tool", "PkgToSoftwareBOM.jl", "")]
     CreatorComment::Union{AbstractString, Missing}= missing
     DocumentComment::Union{AbstractString, Missing}= missing
-    rootpackages::Dict{String, Base.UUID}= Pkg.project().dependencies
+    rootpackages::Dict{String, Base.UUID}= environment_rootpackages()
     packageInstructions::Dict{UUID, spdxPackageInstructions}= Dict{UUID, spdxPackageInstructions}()
     licenseScan::Bool= true
     use_packageserver::Bool= false

--- a/src/PkgToSoftwareBOM.jl
+++ b/src/PkgToSoftwareBOM.jl
@@ -29,7 +29,8 @@ Base.@kwdef struct PackageRegistryInfo
     packageSubdir::String
     packageTreeHash::Union{String, Nothing}
     packageserverURL::Union{String, Nothing}
-    
+    versionInRegistry::Bool= true
+
     # It would be nice to add these fields, but first have to figure out how to resolve version ranges
     #packageCompatibility::Dict{String, Any}
     #PackageDependencies::Dict{String, Any}

--- a/src/Registry.jl
+++ b/src/Registry.jl
@@ -8,10 +8,6 @@ function registry_packagequery(packages::Dict{UUID, Pkg.API.PackageInfo}, regist
     else
         server_registry_info= nothing
     end
-    
-    if length(registries) == 1
-        return _registry_packagequery(packages, registries[1], server_registry_info)
-    end
 
     registry_pkg= Dict{UUID, Union{Nothing, Missing, PackageRegistryInfo}}()
     querylist= packages
@@ -21,11 +17,29 @@ function registry_packagequery(packages::Dict{UUID, Pkg.API.PackageInfo}, regist
         emptykeys= keys(filter(p-> isnothing(p.second) || ismissing(p.second), registry_pkg))
         querylist= Dict{UUID, Pkg.API.PackageInfo}(k => packages[k] for k in emptykeys)
     end
+
+    # Second pass: a registry-tracked package whose installed version is registered in none of the
+    # registries, but whose UUID is registered, can still be described precisely from the registry's
+    # repository and the installed package's own git tree hash. This commonly happens when a package is
+    # updated in the environment while the local registry copy lags behind. The first registry (in the
+    # given order) that knows the package supplies the information.
+    stillmissing= Dict{UUID, Pkg.API.PackageInfo}(k => packages[k] for k in keys(registry_pkg) if ismissing(registry_pkg[k]))
+    for reg in registries
+        isempty(stillmissing) && break
+        reglist= _registry_packagequery(stillmissing, reg, server_registry_info, true)
+        for (k, v) in reglist
+            if v isa PackageRegistryInfo
+                registry_pkg[k]= v
+                delete!(stillmissing, k)
+            end
+        end
+    end
+
     return registry_pkg
 end
 
 ###############################
-function _registry_packagequery(packages::Dict{UUID, Pkg.API.PackageInfo}, registry::AbstractString, server_registry_info)
+function _registry_packagequery(packages::Dict{UUID, Pkg.API.PackageInfo}, registry::AbstractString, server_registry_info, allow_missing_version::Bool= false)
     #Get the requested registry
     active_regs= reachable_registries()
     selected_registry= nothing
@@ -51,45 +65,56 @@ function _registry_packagequery(packages::Dict{UUID, Pkg.API.PackageInfo}, regis
             packageserver= nothing
         end
     end
-    
-    registry_pkg= Dict{Base.UUID, Union{Nothing, Missing, PackageRegistryInfo}}(k => populate_registryinfo(k, packages[k], selected_registry, packageserver) for k in keys(packages))
-    
+
+    registry_pkg= Dict{Base.UUID, Union{Nothing, Missing, PackageRegistryInfo}}(k => populate_registryinfo(k, packages[k], selected_registry, packageserver, allow_missing_version) for k in keys(packages))
+
     return registry_pkg
 end
 
 ###############################
-function populate_registryinfo(uuid::UUID, package::Pkg.API.PackageInfo, registry::RegistryInstance, packageserver::Union{String, Nothing})
+function populate_registryinfo(uuid::UUID, package::Pkg.API.PackageInfo, registry::RegistryInstance, packageserver::Union{String, Nothing}, allow_missing_version::Bool= false)
     package.is_tracking_repo && return nothing
 
     if package.is_tracking_registry || package.is_tracking_path
         # Look up the package in the registry by UUID
         haskey(registry.pkgs, uuid) || return missing
         registryPkg= registry.pkgs[uuid]
-    
+
         # Check package and the registry are using the same name
         (package.name == registryPkg.name) || error("Conflicting package names found: $(string(uuid))=> $(package.name)(environment) vs. $(registryPkg.name)(registry)")
     else
         println("Malformed PackageInfo:  $(string(uuid)) => $(package.name)")  # TODO: Work on this
         return nothing
     end
-    
+
     registryPkgData= registry_info(registryPkg)
 
     # TODO: Resolve the correct Compat and Deps for this version
 
-    # Verify that the version exists in this registry
-    haskey(registryPkgData.version_info, package.version) || return missing
+    # Determine whether the installed version is registered. When it is not, the registry can still supply
+    # the package's repository, and the installed package's own git tree hash identifies the exact source.
+    # This precise fallback is offered only for registry-tracked packages, and only when the caller allows it.
+    version_in_registry= haskey(registryPkgData.version_info, package.version)
+    version_in_registry || (allow_missing_version && package.is_tracking_registry) || return missing
 
     packageSubdir= isnothing(registryPkgData.subdir) ? "" : registryPkgData.subdir
 
-    tree_hash= haskey(registryPkgData.version_info, package.version) ? treehash(registryPkgData, package.version) : nothing
-
-    # Verify the tree hash in the registry matches the hash in the package. This check usually (always?) fails with an stdlib, even if it is tracked in the registry, becuase package.tree_hash is nothing.
-    if !is_stdlib(uuid)
-        package.is_tracking_registry && string(tree_hash) !== package.tree_hash && error("Tree hash of $(package.name) v$(string(package.version)) does not match registry:  $(string(package.tree_hash)) (Package) vs. $(treehash(registryPkgData, package.version)) (Registry)")
+    if version_in_registry
+        tree_hash= string(treehash(registryPkgData, package.version))
+        # Verify the tree hash in the registry matches the hash in the package. This check usually (always?) fails with an stdlib, even if it is tracked in the registry, becuase package.tree_hash is nothing.
+        if !is_stdlib(uuid)
+            package.is_tracking_registry && tree_hash !== package.tree_hash && error("Tree hash of $(package.name) v$(string(package.version)) does not match registry:  $(string(package.tree_hash)) (Package) vs. $(tree_hash) (Registry)")
+        end
+    else
+        # The registry knows this package but not the installed version. Without an installed tree hash there
+        # is nothing precise to report, so leave the package unresolved for the NOASSERTION fallback.
+        isnothing(package.tree_hash) && return missing
+        tree_hash= package.tree_hash
     end
 
-    packageserverURL= isnothing(packageserver) ? nothing : packageserver * "/$(uuid)/$(package.tree_hash)"
+    # A package server serves the versions the registry knows about, so it cannot supply an unregistered
+    # version. Fall back to the repository download in that case.
+    packageserverURL= (isnothing(packageserver) || !version_in_registry) ? nothing : packageserver * "/$(uuid)/$(package.tree_hash)"
 
     pkgRegInfo= PackageRegistryInfo(;
         registryName= registry.name,
@@ -101,17 +126,18 @@ function populate_registryinfo(uuid::UUID, package::Pkg.API.PackageInfo, registr
         packageVersion= package.version,
         packageURL= registryPkgData.repo,
         packageSubdir= packageSubdir,
-        packageTreeHash= string(tree_hash),
-        packageserverURL= packageserverURL
+        packageTreeHash= tree_hash,
+        packageserverURL= packageserverURL,
+        versionInRegistry= version_in_registry
     )
-    
+
     return pkgRegInfo
 end
 
 ################################
 ## The code below has been copied from Julia Package Manager v1.10.4 and modified as needed
 ##     https://github.com/JuliaLang/Pkg.jl/tree/v1.10.4
-#  
+#
 #  Copyright (c) 2017-2021: Stefan Karpinski, Kristoffer Carlsson, Fredrik Ekre, David Varela, Ian Butterworth, and contributors: 
 #  https://github.com/JuliaLang/Pkg.jl/graphs/contributors
 #

--- a/src/packageInfo.jl
+++ b/src/packageInfo.jl
@@ -1,6 +1,36 @@
 # SPDX-License-Identifier: MIT
 
 ###############################
+# The direct dependencies used as the root packages of the SBOM. In a Julia 1.12+ workspace this
+# combines the direct dependencies of the top level project and of every workspace member project.
+function environment_rootpackages(env::Pkg.Types.EnvCache= Pkg.Types.Context().env)
+    rootpackages= copy(env.project.deps)
+    if hasproperty(env, :workspace)
+        for project in values(env.workspace)
+            merge!(rootpackages, project.deps)
+        end
+    end
+    return rootpackages
+end
+
+###############################
+# PackageInfo for every dependency in the active environment. Workspaces exist only on Julia 1.12+,
+# where Pkg.dependencies() prunes the shared manifest down to packages reachable from the top level
+# project alone and so drops the workspace member projects' dependencies. On those versions this
+# reproduces Pkg.Operations.load_all_deps_loadable (the basis of Pkg.dependencies()): take every
+# dependency in the manifest, then keep those reachable from the root packages. Seeding the reachable
+# set from environment_rootpackages, rather than from the top level project alone, retains the
+# dependencies of every workspace member project while still excluding the projects themselves.
+# On older versions there are no workspaces, so Pkg.dependencies() is already complete.
+function environment_dependencies(env::Pkg.Types.EnvCache= Pkg.Types.Context().env)
+    hasproperty(env, :workspace) || return Pkg.dependencies(env)
+    deps= Pkg.Operations.load_all_deps(env)
+    keep= Set{UUID}(values(environment_rootpackages(env)))
+    Pkg.Operations.prune_deps(env.manifest, keep)
+    return Dict{UUID, Pkg.API.PackageInfo}(pkg.uuid => Pkg.API.package_info(env, pkg) for pkg in deps if pkg.uuid in keep)
+end
+
+###############################
 function resolve_pkgsource!(uuid::UUID, package::SpdxPackageV2, packagedata::Pkg.API.PackageInfo, registrydata::Union{Nothing, Missing, PackageRegistryInfo})
     # The location of the SPDX package's source code depend on whether Pkg is tracking the package via:
     #   1) A package listed in the registry; Some stdlibs are tracked in the General registry, some are not.

--- a/src/packageInfo.jl
+++ b/src/packageInfo.jl
@@ -71,6 +71,12 @@ function resolve_pkgsource!(uuid::UUID, package::SpdxPackageV2, packagedata::Pkg
         else
             package.HomePage= registrydata.packageURL
         end
+
+        if !registrydata.versionInRegistry
+            # The version installed in the environment was not listed in the registry, so the download
+            # location was resolved from the registry's repository and the installed package's git tree hash.
+            package.SourceInfo= package.SourceInfo * "\nVersion $(string(registrydata.packageVersion)) was not found in the $(registrydata.registryName) registry; the registry copy may be out of date. The Download Location was resolved from the registry's repository and the installed package's git tree hash."
+        end
     elseif packagedata.is_tracking_repo
         # Next simplest case is if you are directly tracking a repository
         # TODO: Extract the subdirectory information if it exists. Can't find it in packagedata.
@@ -101,7 +107,16 @@ function resolve_pkgsource!(uuid::UUID, package::SpdxPackageV2, packagedata::Pkg
         package.HomePage= "https://julialang.org"
         package.Supplier= SpdxCreatorV2("Organization", "JuliaLang", "")
     elseif packagedata.is_tracking_registry && ismissing(registrydata)
-        error("Package $(packagedata.name) and/or its version cannot be found in the specified registries.\nPlease review the installed registries with Pkg and the value of parameter \'sbomRegistries\' when the function \'generateSPDX\' is called")
+        # The package tracks a registry, but the installed version was not found in any of the specified
+        # registries. This commonly happens when a package is updated in the environment while the local
+        # registry copy lags behind. Rather than aborting the whole SBOM, record what the installed package
+        # itself provides and note that the download location could not be resolved.
+        @warn "Package $(packagedata.name) v$(string(packagedata.version)) and/or its version cannot be found in the specified registries. The registry copy may be out of date. Recording the package with limited source information.\nReview the installed registries with Pkg and the value of parameter 'sbomRegistries' when the function 'generateSPDX' is called."
+        package.DownloadLocation= SpdxDownloadLocationV2("NOASSERTION")
+        package.HomePage= "NOASSERTION"
+        package.SourceInfo= "$(packagedata.name) v$(string(packagedata.version)) tracks a registry, but this version could not be found in the specified registries. The registry copy may be out of date, so a download location could not be determined."
+        isnothing(packagedata.tree_hash) || (package.SourceInfo= package.SourceInfo * "\nThe git tree hash of the installed package is $(packagedata.tree_hash).")
+        package.Supplier= SpdxCreatorV2("NOASSERTION")
     else
         # This should not happen unless there has been a breaking change in Pkg
         error("PkgToSBOM.resolve_pkgsource!():  Unable to resolve source information for $(packagedata.name). Maybe the Pkg source has changed in a breaking way?")

--- a/src/spdxBuild.jl
+++ b/src/spdxBuild.jl
@@ -15,7 +15,7 @@ For example to create a User Environment SBOM using the General registry and ano
 sbom= generateSPDX(spdxCreationData(), ["PrivateRegistry", "General"]);
 ```
 """
-function generateSPDX(docData::spdxCreationData= spdxCreationData(), sbomRegistries::Vector{<:AbstractString}= ["General"], envpkgs::Dict{Base.UUID, Pkg.API.PackageInfo}= Pkg.dependencies())
+function generateSPDX(docData::spdxCreationData= spdxCreationData(), sbomRegistries::Vector{<:AbstractString}= ["General"], envpkgs::Dict{Base.UUID, Pkg.API.PackageInfo}= environment_dependencies())
     # Query the registries for package information
     registry_packages= registry_packagequery(envpkgs, sbomRegistries, docData.use_packageserver)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,6 +255,46 @@ using Base.BinaryPlatforms
         @test SPDX.compare_b(sbom_lazy.Packages[packageindex].VerificationCode, sbom_downloaded.Packages[packageindex].VerificationCode)
     end
 
+    if VERSION >= v"1.12"
+        @testset "Workspace environment" begin
+            # A workspace shares one manifest between the top level project and its member
+            # projects. The SBOM must describe the dependencies of every member project, not
+            # just those reachable from the top level project.
+            wsdir= mktempdir()
+            mkdir(joinpath(wsdir, "sub"))
+            write(joinpath(wsdir, "Project.toml"),
+                """
+                name = "WorkspaceRoot"
+                uuid = "11111111-1111-1111-1111-111111111111"
+                version = "0.1.0"
+
+                [deps]
+                Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+                [workspace]
+                projects = ["sub"]
+                """)
+            write(joinpath(wsdir, "sub", "Project.toml"),
+                """
+                [deps]
+                Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+                """)
+            Pkg.activate(wsdir)
+            Pkg.instantiate()
+
+            # Crayons is a dependency of the member project only; Example of the top level project
+            @test issetequal(keys(PkgToSoftwareBOM.environment_rootpackages()), ["Example", "Crayons"])
+            @test issetequal([d.name for d in values(PkgToSoftwareBOM.environment_dependencies())], ["Example", "Crayons"])
+
+            sbom= generateSPDX(spdxCreationData(licenseScan= false))
+            described= filter(r -> r.RelationshipType == "DESCRIBES", sbom.Relationships)
+            @test issetequal(getproperty.(described, :RelatedSPDXID),
+                ["SPDXRef-Example-7876af07-990d-54b4-ab0e-23690620f79a",
+                 "SPDXRef-Crayons-a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"])
+            @test issetequal(getproperty.(sbom.Packages, :Name), ["Example", "Crayons"])
+        end
+    end
+
     # Remove registry
     Pkg.Registry.rm("DummyRegistry")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -229,8 +229,18 @@ using Base.BinaryPlatforms
         # a warning is logged for each unresolved package.
         sbom_noregistry= @test_logs (:warn,) match_mode=:any generateSPDX(spdxCreationData(rootpackages= filter(p-> (p.first in ["Dummy4"]), Pkg.project().dependencies)));
         @test issetequal(getproperty.(sbom_noregistry.Packages, :Name), ["Dummy1", "Dummy2", "Dummy3", "Dummy4"])
-        @test all(isequal.(getproperty.(sbom_noregistry.Packages, :DownloadLocation), [SpdxDownloadLocationV2("NOASSERTION")]))
-        @test all(isequal.(getproperty.(sbom_noregistry.Packages, :HomePage), "NOASSERTION"))
+        # Dummy1-3 are registered in DummyRegistry. Without that registry their source cannot be resolved,
+        # so their download location and home page fall back to NOASSERTION.
+        for name in ("Dummy1", "Dummy2", "Dummy3")
+            pkg= sbom_noregistry.Packages[findfirst(isequal(name), getproperty.(sbom_noregistry.Packages, :Name))]
+            @test pkg.DownloadLocation == SpdxDownloadLocationV2("NOASSERTION")
+            @test pkg.HomePage == "NOASSERTION"
+        end
+        # Dummy4 directly tracks its git repository, so its download location and home page are resolved
+        # from the package itself, independent of any registry.
+        dummy4_noregistry= sbom_noregistry.Packages[findfirst(isequal("Dummy4"), getproperty.(sbom_noregistry.Packages, :Name))]
+        @test dummy4_noregistry.DownloadLocation == SpdxDownloadLocationV2("git+https://github.com/SamuraiAku/Dummy4.git@v1.0.0")
+        @test dummy4_noregistry.HomePage == "https://github.com/SamuraiAku/Dummy4.git"
     end
 
     @testset "Artifact Tests" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,8 +224,13 @@ using Base.BinaryPlatforms
         sbom2= generateSPDX(spdxCreationData(rootpackages= filter(p-> (p.first in ["Dummy4"]), Pkg.project().dependencies), use_packageserver= true), ["DummyRegistry", "General"]);
         @test issetequal(sbom.Packages, sbom2.Packages)
 
-        # If we don't specify DummyRegistry when building the SBOM we expect an error
-        @test_throws "its version cannot be found in the specified registries" sbom= generateSPDX();
+        # If we don't specify DummyRegistry when building the SBOM, the packages cannot be found in the
+        # registry. Rather than aborting, the SBOM is still generated with limited source information and
+        # a warning is logged for each unresolved package.
+        sbom_noregistry= @test_logs (:warn,) match_mode=:any generateSPDX(spdxCreationData(rootpackages= filter(p-> (p.first in ["Dummy4"]), Pkg.project().dependencies)));
+        @test issetequal(getproperty.(sbom_noregistry.Packages, :Name), ["Dummy1", "Dummy2", "Dummy3", "Dummy4"])
+        @test all(isequal.(getproperty.(sbom_noregistry.Packages, :DownloadLocation), [SpdxDownloadLocationV2("NOASSERTION")]))
+        @test all(isequal.(getproperty.(sbom_noregistry.Packages, :HomePage), "NOASSERTION"))
     end
 
     @testset "Artifact Tests" begin
@@ -235,7 +240,7 @@ using Base.BinaryPlatforms
 
         download_artifact()
         sbom_downloaded= generateSPDX(spdxCreationData(rootpackages= filter(p-> (p.first in ["MWETestSBOM_LazyArtifact"]), Pkg.project().dependencies)), ["DummyRegistry", "General"]);
-        
+
         remove_artifact()
         sbom_lazy= generateSPDX(spdxCreationData(rootpackages= filter(p-> (p.first in ["MWETestSBOM_LazyArtifact"]), Pkg.project().dependencies)), ["DummyRegistry", "General"]);
 


### PR DESCRIPTION
There are legitimate reasons why a package (version) is not in the registry, e.g. because the general registry is not yet updated (just happened today for more than 10 hours).

It's not fully clear whether this is worth the complexity, but logically it seems to be the right thing to do.

This builds on the support_workspace branch, so the diff will be smaller after merging that one.